### PR TITLE
Resolution for Issue #1, added SQLAlchemy ORM dialect types for MySQL

### DIFF
--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -42,32 +42,32 @@ class ModelConverter(object):
         postgresql.MACADDR: fields.String,
         postgresql.INET: fields.String,
 
-	mysql.BIT: fields.Integer,
-	mysql.TINYINT: fields.Integer,
-	mysql.SMALLINT: fields.Integer,
-	mysql.INTEGER: fields.Integer,
-	mysql.BIGINT: fields.Integer,
+        mysql.BIT: fields.Integer,
+        mysql.TINYINT: fields.Integer,
+        mysql.SMALLINT: fields.Integer,
+        mysql.INTEGER: fields.Integer,
+        mysql.BIGINT: fields.Integer,
 
-	mysql.NUMERIC: fields.Decimal,
-	mysql.DECIMAL: fields.Decimal,
+        mysql.NUMERIC: fields.Decimal,
+        mysql.DECIMAL: fields.Decimal,
 
-	mysql.DATETIME: fields.DateTime,
-	mysql.DATE: fields.Date,
-	mysql.TIME: fields.Time,
-	mysql.YEAR: fields.Integer,
+        mysql.DATETIME: fields.DateTime,
+        mysql.DATE: fields.Date,
+        mysql.TIME: fields.Time,
+        mysql.YEAR: fields.Integer,
 
-	mysql.TEXT: fields.String,
-	mysql.TINYTEXT: fields.String,
-	mysql.MEDIUMTEXT: fields.String,
-	mysql.LONGTEXT: fields.String,
+        mysql.TEXT: fields.String,
+        mysql.TINYTEXT: fields.String,
+        mysql.MEDIUMTEXT: fields.String,
+        mysql.LONGTEXT: fields.String,
 
-	mysql.BLOB: fields.String,
-	mysql.TINYBLOB: fields.String,
-	mysql.MEDIUMBLOB: fields.String,
-	mysql.LONGBLOB: fields.String,
+        mysql.BLOB: fields.String,
+        mysql.TINYBLOB: fields.String,
+        mysql.MEDIUMBLOB: fields.String,
+        mysql.LONGBLOB: fields.String,
 
-	mysql.SET: fields.List,
-	mysql.ENUM: fields.Enum
+        mysql.SET: fields.List,
+        mysql.ENUM: fields.Enum
 
     }
 

--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -4,7 +4,7 @@ import inspect
 import marshmallow as ma
 from marshmallow import validate, fields
 from marshmallow.compat import text_type
-from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects import postgresql, mysql
 from sqlalchemy.orm.util import identity_key
 import sqlalchemy as sa
 
@@ -37,9 +37,38 @@ class ModelConverter(object):
         sa.Numeric: fields.Decimal,
         sa.Float: fields.Decimal,
         sa.Date: fields.Date,
+
         postgresql.UUID: fields.UUID,
         postgresql.MACADDR: fields.String,
         postgresql.INET: fields.String,
+
+	mysql.BIT: fields.Integer,
+	mysql.TINYINT: fields.Integer,
+	mysql.SMALLINT: fields.Integer,
+	mysql.INTEGER: fields.Integer,
+	mysql.BIGINT: fields.Integer,
+
+	mysql.NUMERIC: fields.Decimal,
+	mysql.DECIMAL: fields.Decimal,
+
+	mysql.DATETIME: fields.DateTime,
+	mysql.DATE: fields.Date,
+	mysql.TIME: fields.Time,
+	mysql.YEAR: fields.Integer,
+
+	mysql.TEXT: fields.String,
+	mysql.TINYTEXT: fields.String,
+	mysql.MEDIUMTEXT: fields.String,
+	mysql.LONGTEXT: fields.String,
+
+	mysql.BLOB: fields.String,
+	mysql.TINYBLOB: fields.String,
+	mysql.MEDIUMBLOB: fields.String,
+	mysql.LONGBLOB: fields.String,
+
+	mysql.SET: fields.List,
+	mysql.ENUM: fields.Enum
+
     }
 
     DIRECTION_MAPPING = {


### PR DESCRIPTION
Found that convert.py was missing the correct stitching for SQLAlchemy ORM dialect for MySQL column types.  Added as pull request per @sloria.

Cheers!
