### PR TITLE
Refactor related

### DIFF
--- a/marshmallow_sqlalchemy/__init__.py
+++ b/marshmallow_sqlalchemy/__init__.py
@@ -9,7 +9,6 @@ from .schema import (
 from .convert import (
     ModelConverter,
     fields_for_model,
-    get_pk_from_identity,
     property2field,
     column2field,
     field_for,

--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -4,24 +4,11 @@ import functools
 
 import marshmallow as ma
 from marshmallow import validate, fields
-from marshmallow.compat import text_type
 from sqlalchemy.dialects import postgresql, mysql
-from sqlalchemy.orm.util import identity_key
 import sqlalchemy as sa
 
 from .exceptions import ModelConversionError
 from .fields import Related
-
-def get_pk_from_identity(obj):
-    """Get primary key for `obj`. If `obj` has a compound primary key,
-    return a string of keys separated by ``":"``. This is the default keygetter for
-    used by `ModelSchema <marshmallow_sqlalchemy.ModelSchema>`.
-    """
-    _, key = identity_key(instance=obj)
-    if len(key) == 1:
-        return key[0]
-    else:  # Compund primary key
-        return ':'.join(text_type(x) for x in key)
 
 def _is_field(value):
     return (
@@ -64,7 +51,7 @@ class ModelConverter(object):
         'ONETOMANY': True,
     }
 
-    def fields_for_model(self, model, session=None, include_fk=False, keygetter=None, fields=None):
+    def fields_for_model(self, model, session=None, include_fk=False, fields=None):
         result = {}
         for prop in model.__mapper__.iterate_properties:
             if fields and prop.key not in fields:
@@ -72,18 +59,16 @@ class ModelConverter(object):
             if hasattr(prop, 'columns'):
                 if not include_fk and prop.columns[0].foreign_keys:
                     continue
-            field = self.property2field(prop, session=session, keygetter=keygetter)
+            field = self.property2field(prop, session=session)
             if field:
                 result[prop.key] = field
         return result
 
-    def property2field(self, prop, session=None, keygetter=None, instance=True, **kwargs):
+    def property2field(self, prop, session=None, instance=True, **kwargs):
         field_class = self._get_field_class_for_property(prop)
         if not instance:
             return field_class
-        field_kwargs = self._get_field_kwargs_for_property(
-            prop, session=session, keygetter=keygetter
-        )
+        field_kwargs = self._get_field_kwargs_for_property(prop, session=session)
         field_kwargs.update(kwargs)
         ret = field_class(**field_kwargs)
         if hasattr(prop, 'direction') and self.DIRECTION_MAPPING[prop.direction.name]:
@@ -133,13 +118,13 @@ class ModelConverter(object):
             field_cls = self._get_field_class_for_column(column)
         return field_cls
 
-    def _get_field_kwargs_for_property(self, prop, session=None, keygetter=None):
+    def _get_field_kwargs_for_property(self, prop, session=None):
         kwargs = self.get_base_kwargs()
         if hasattr(prop, 'columns'):
             column = prop.columns[0]
             self._add_column_kwargs(kwargs, column)
         if hasattr(prop, 'direction'):  # Relationship property
-            self._add_relationship_kwargs(kwargs, prop, session=session, keygetter=keygetter)
+            self._add_relationship_kwargs(kwargs, prop, session=session)
         if getattr(prop, 'doc', None):  # Useful for documentation generation
             kwargs['description'] = prop.doc
         return kwargs
@@ -165,7 +150,7 @@ class ModelConverter(object):
         if getattr(column, 'primary_key', False):
             kwargs['dump_only'] = True
 
-    def _add_relationship_kwargs(self, kwargs, prop, session, keygetter=None):
+    def _add_relationship_kwargs(self, kwargs, prop, session):
         """Add keyword arguments to kwargs (in-place) based on the passed in
         relationship `Property`.
         """
@@ -201,8 +186,6 @@ property2field = default_converter.property2field
 
 :param Property prop: SQLAlchemy Property.
 :param Session session: SQLALchemy session.
-:param keygetter: See `marshmallow.fields.QuerySelect` for documenation on the
-    keygetter parameter.
 :param bool instance: If `True`, return  `Field` instance, computing relevant kwargs
     from the given property. If `False`, return the `Field` class.
 :param kwargs: Additional keyword arguments to pass to the field constructor.

--- a/marshmallow_sqlalchemy/fields.py
+++ b/marshmallow_sqlalchemy/fields.py
@@ -27,7 +27,7 @@ class Related(fields.Field):
 
     @property
     def related_model(self):
-        return getattr(self.model, self.attribute or self.name).class_
+        return getattr(self.model, self.attribute or self.name).property.mapper.class_
 
     @property
     def related_column(self):

--- a/marshmallow_sqlalchemy/fields.py
+++ b/marshmallow_sqlalchemy/fields.py
@@ -29,7 +29,7 @@ class Related(fields.Field):
         return self.parent.opts.sqla_session
 
     def _serialize(self, value, attr, obj):
-        return getattr(value, self.related_column.key)
+        return getattr(value, self.related_column.key, None)
 
     def _deserialize(self, value):
         return self.session.query(

--- a/marshmallow_sqlalchemy/fields.py
+++ b/marshmallow_sqlalchemy/fields.py
@@ -21,6 +21,10 @@ class Related(fields.Field):
     as :class:`ModelSchema`.
     """
 
+    def __init__(self, column=None, **kwargs):
+        super(Related, self).__init__(**kwargs)
+        self.column = column
+
     @property
     def model(self):
         return self.parent.opts.model
@@ -31,6 +35,10 @@ class Related(fields.Field):
 
     @property
     def related_column(self):
+        if self.column:
+            if isinstance(self.column, sa.Column):
+                return self.column
+            return self.model.__mapper__.columns[self.column]
         return get_primary_column(self.related_model)
 
     @property

--- a/marshmallow_sqlalchemy/fields.py
+++ b/marshmallow_sqlalchemy/fields.py
@@ -19,6 +19,9 @@ class Related(fields.Field):
     """Related data represented by a SQLAlchemy `relationship`. Must be attached
     to a :class:`Schema` class whose options includes a SQLAlchemy `model`, such
     as :class:`ModelSchema`.
+
+    :param str column: Optional column name on related model. If not provided,
+        the primary key of the related model will be used.
     """
 
     def __init__(self, column=None, **kwargs):
@@ -36,9 +39,7 @@ class Related(fields.Field):
     @property
     def related_column(self):
         if self.column:
-            if isinstance(self.column, sa.Column):
-                return self.column
-            return self.model.__mapper__.columns[self.column]
+            return self.related_model.__mapper__.columns[self.column]
         return get_primary_column(self.related_model)
 
     @property

--- a/marshmallow_sqlalchemy/fields.py
+++ b/marshmallow_sqlalchemy/fields.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+from marshmallow import fields
+
+
+def get_primary_column(model):
+    columns = model.__mapper__.primary_key
+    if len(columns) == 1:
+        return columns[0]
+    raise RuntimeError('Model {0!r} has multiple primary keys'.format(model))
+
+
+class Related(fields.Field):
+
+    @property
+    def model(self):
+        return self.parent.opts.model
+
+    @property
+    def related_model(self):
+        return getattr(self.model, self.attribute or self.name).class_
+
+    @property
+    def related_column(self):
+        return get_primary_column(self.related_model)
+
+    @property
+    def session(self):
+        return self.parent.opts.sqla_session
+
+    def _serialize(self, value, attr, obj):
+        return getattr(value, self.related_column.key)
+
+    def _deserialize(self, value):
+        return self.session.query(
+            self.related_model
+        ).filter(
+            self.related_column == value
+        ).one()

--- a/marshmallow_sqlalchemy/fields.py
+++ b/marshmallow_sqlalchemy/fields.py
@@ -4,6 +4,11 @@ from marshmallow import fields
 
 
 def get_primary_column(model):
+    """Get primary key column for a SQLAlchemy model.
+
+    :param model: SQLAlchemy model class
+    :raise: RuntimeError if model has multiple primary key columns
+    """
     columns = model.__mapper__.primary_key
     if len(columns) == 1:
         return columns[0]
@@ -11,6 +16,10 @@ def get_primary_column(model):
 
 
 class Related(fields.Field):
+    """Related data represented by a SQLAlchemy `relationship`. Must be attached
+    to a :class:`Schema` class whose options includes a SQLAlchemy `model`, such
+    as :class:`ModelSchema`.
+    """
 
     @property
     def model(self):

--- a/marshmallow_sqlalchemy/schema.py
+++ b/marshmallow_sqlalchemy/schema.py
@@ -43,7 +43,6 @@ class SchemaMeta(ma.schema.SchemaMeta):
                 converter = Converter()
                 declared_fields = converter.fields_for_model(
                     opts.model,
-                    opts.sqla_session,
                     fields=opts.fields,
                 )
                 break

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -379,6 +379,21 @@ class TestModelSchema:
         assert result.data.id is None
         assert result.data.current_school == student.current_school
 
+    def test_model_schema_custom_related_column(self, models, schemas, student, session):
+        class StudentSchema(ModelSchema):
+            class Meta:
+                model = models.Student
+                sqla_session = session
+            current_school = Related(column='name')
+
+        schema = StudentSchema()
+        dump_data = schema.dump(student).data
+        result = schema.load(dump_data)
+
+        assert type(result.data) == models.Student
+        assert result.data.id is None
+        assert result.data.current_school == student.current_school
+
     def test_fields_option(self, student, models, session):
         class StudentSchema(ModelSchema):
             class Meta:

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -352,12 +352,14 @@ class TestModelSchema:
     def school(self, models, session):
         school_ = models.School(name='Univ. Of Whales')
         session.add(school_)
+        session.flush()
         return school_
 
     @pytest.fixture()
     def student(self, models, school, session):
         student_ = models.Student(full_name='Monty Python', current_school=school)
         session.add(student_)
+        session.flush()
         return student_
 
     def test_model_schema_dumping(self, schemas, student, session):
@@ -375,6 +377,7 @@ class TestModelSchema:
 
         assert type(result.data) == models.Student
         assert result.data.id is None
+        assert result.data.current_school == student.current_school
 
     def test_fields_option(self, student, models, session):
         class StudentSchema(ModelSchema):
@@ -445,12 +448,14 @@ class TestNullForeignKey:
     def school(self, models, session):
         school_ = models.School(name='The Teacherless School')
         session.add(school_)
+        session.flush()
         return school_
 
     @pytest.fixture()
     def teacher(self, models, school, session):
         teacher_ = models.Teacher(full_name='The Schoolless Teacher')
         session.add(teacher_)
+        session.flush()
         return teacher_
 
     def test_a_teacher_with_no_school(self, models, schemas, teacher, session):

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -15,6 +15,7 @@ from marshmallow_sqlalchemy import (
     fields_for_model, ModelSchema, ModelConverter, property2field, column2field,
     field_for,
 )
+from marshmallow_sqlalchemy.fields import Related
 
 def contains_validator(field, v_type):
     for v in field.validators:
@@ -175,25 +176,17 @@ class TestModelFieldConversion:
 
     def test_many_to_many_relationship(self, models, session):
         student_fields = fields_for_model(models.Student, session=session)
-        assert type(student_fields['courses']) is fields.QuerySelectList
+        assert type(student_fields['courses']) is fields.List
 
         course_fields = fields_for_model(models.Course, session=session)
-        assert type(course_fields['students']) is fields.QuerySelectList
+        assert type(course_fields['students']) is fields.List
 
     def test_many_to_one_relationship(self, models, session):
         student_fields = fields_for_model(models.Student, session=session)
-        assert type(student_fields['current_school']) is fields.QuerySelect
+        assert type(student_fields['current_school']) is Related
 
         school_fields = fields_for_model(models.School, session=session)
-        assert type(school_fields['students']) is fields.QuerySelectList
-
-    def test_custom_keygetter(self, models, session):
-        student_fields = fields_for_model(
-            models.Student,
-            session=session,
-            keygetter=hyperlink_keygetter
-        )
-        assert student_fields['current_school'].keygetter == hyperlink_keygetter
+        assert type(school_fields['students']) is fields.List
 
     def test_include_fk(self, models, session):
         student_fields = fields_for_model(models.Student, session=session, include_fk=False)
@@ -338,7 +331,7 @@ class TestFieldFor:
         assert type(field) == fields.Str
 
         field = field_for(models.Student, 'current_school', session=session)
-        assert type(field) == fields.QuerySelect
+        assert type(field) == Related
 
 class TestModelSchema:
 
@@ -355,7 +348,6 @@ class TestModelSchema:
         return student_
 
     def test_model_schema_dumping(self, schemas, student, session):
-        session.commit()
         schema = schemas.StudentSchema()
         result = schema.dump(student)
         # fk excluded by default
@@ -363,14 +355,7 @@ class TestModelSchema:
         # related field dumps to pk
         assert result.data['current_school'] == student.current_school.id
 
-    def test_model_schema_overridden_keygeter(self, schemas, student, session):
-        session.commit()
-        schema = schemas.HyperlinkStudentSchema()
-        result = schema.dump(student)
-        assert result.data['current_school'] == student.current_school.url
-
     def test_model_schema_loading(self, models, schemas, student, session):
-        session.commit()
         schema = schemas.StudentSchema()
         dump_data = schema.dump(student).data
         result = schema.load(dump_data)

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -104,9 +104,6 @@ def models(Base):
             self.Student = Student
     return _models()
 
-def hyperlink_keygetter(obj):
-    return obj.url
-
 @pytest.fixture()
 def schemas(models, session):
     class CourseSchema(ModelSchema):
@@ -128,7 +125,6 @@ def schemas(models, session):
         class Meta:
             model = models.Student
             sqla_session = session
-            keygetter = hyperlink_keygetter
 
     # Again, so we can use dot-notation
     class _schemas(object):

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -155,57 +155,57 @@ def schemas(models, session):
 
 class TestModelFieldConversion:
 
-    def test_fields_for_model_types(self, models, session):
-        fields_ = fields_for_model(models.Student, session=session, include_fk=True)
+    def test_fields_for_model_types(self, models):
+        fields_ = fields_for_model(models.Student, include_fk=True)
         assert type(fields_['id']) is fields.Int
         assert type(fields_['full_name']) is fields.Str
         assert type(fields_['dob']) is fields.Date
         assert type(fields_['current_school_id']) is fields.Int
         assert type(fields_['date_created']) is fields.DateTime
 
-    def test_fields_for_model_handles_custom_types(self, models, session):
-        fields_ = fields_for_model(models.Course, session=session, include_fk=True)
+    def test_fields_for_model_handles_custom_types(self, models):
+        fields_ = fields_for_model(models.Course, include_fk=True)
         assert type(fields_['grade']) is fields.Int
 
-    def test_fields_for_model_saves_doc(self, models, session):
-        fields_ = fields_for_model(models.Student, session=session, include_fk=True)
+    def test_fields_for_model_saves_doc(self, models):
+        fields_ = fields_for_model(models.Student, include_fk=True)
         assert fields_['date_created'].metadata['description'] == 'date the student was created'
 
-    def test_length_validator_set(self, models, session):
-        fields_ = fields_for_model(models.Student, session=session)
+    def test_length_validator_set(self, models):
+        fields_ = fields_for_model(models.Student)
         validator = contains_validator(fields_['full_name'], validate.Length)
         assert validator
         assert validator.max == 255
 
-    def test_sets_allow_none_for_nullable_fields(self, models, session):
-        fields_ = fields_for_model(models.Student, session)
+    def test_sets_allow_none_for_nullable_fields(self, models):
+        fields_ = fields_for_model(models.Student)
         assert fields_['dob'].allow_none is True
 
-    def test_sets_enum_choices(self, models, session):
-        fields_ = fields_for_model(models.Course, session=session)
+    def test_sets_enum_choices(self, models):
+        fields_ = fields_for_model(models.Course)
         validator = contains_validator(fields_['level'], validate.OneOf)
         assert validator
         assert validator.choices == ('Primary', 'Secondary')
 
-    def test_many_to_many_relationship(self, models, session):
-        student_fields = fields_for_model(models.Student, session=session)
+    def test_many_to_many_relationship(self, models):
+        student_fields = fields_for_model(models.Student)
         assert type(student_fields['courses']) is fields.List
 
-        course_fields = fields_for_model(models.Course, session=session)
+        course_fields = fields_for_model(models.Course)
         assert type(course_fields['students']) is fields.List
 
-    def test_many_to_one_relationship(self, models, session):
-        student_fields = fields_for_model(models.Student, session=session)
+    def test_many_to_one_relationship(self, models):
+        student_fields = fields_for_model(models.Student)
         assert type(student_fields['current_school']) is Related
 
-        school_fields = fields_for_model(models.School, session=session)
+        school_fields = fields_for_model(models.School)
         assert type(school_fields['students']) is fields.List
 
-    def test_include_fk(self, models, session):
-        student_fields = fields_for_model(models.Student, session=session, include_fk=False)
+    def test_include_fk(self, models):
+        student_fields = fields_for_model(models.Student, include_fk=False)
         assert 'current_school_id' not in student_fields
 
-        student_fields2 = fields_for_model(models.Student, session=session, include_fk=True)
+        student_fields2 = fields_for_model(models.Student, include_fk=True)
         assert 'current_school_id' in student_fields2
 
 def make_property(*column_args, **column_kwargs):
@@ -362,7 +362,7 @@ class TestModelSchema:
         session.flush()
         return student_
 
-    def test_model_schema_dumping(self, schemas, student, session):
+    def test_model_schema_dumping(self, schemas, student):
         schema = schemas.StudentSchema()
         result = schema.dump(student)
         # fk excluded by default


### PR DESCRIPTION
Model related rows with `Related` field.

The current implementation of relationship fields based on `QuerySelect`
and `QuerySelectList` fields makes many potentially expensive queries.
This patch adds a SQLAlchemy-specific field, `Related`, and uses it for
relationships.

Note: with the move away from `QuerySelect`, we lose the `keygetter` option.
I'm not sure I liked this interface to begin with (Is it a good idea for all related
fields to use the same keygetter? If keygetter can return some computed
property of a row, how does the user specify a way to load data from the ORM
for efficient deserialization?). If we want to restore functionality like serializing
related URLs instead of primary keys, I think we should subclass the proposed
`Related` field to `HyperlinkRelated`, `SlugRelated`, etc., as in DRF. Thoughts
@sloria?

[Resolves #7]
