### PR TITLE
Handle NULL foreign keys

### DIFF
--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -16,6 +16,9 @@ def get_pk_from_identity(obj):
     return a string of keys separated by ``":"``. This is the default keygetter for
     used by `ModelSchema <marshmallow_sqlalchemy.ModelSchema>`.
     """
+    if obj is None:
+        return None
+
     _, key = identity_key(instance=obj)
     if len(key) == 1:
         return key[0]


### PR DESCRIPTION
Currently if you have two models, Book and Author like in the example, and you create a Book without an author (see Issue #3 ), you'll get an exception `sqlalchemy.orm.exc.UnmappedInstanceError: Class 'builtins.NoneType' is not mapped`  This fixes the handling of that (looking up a primary key on a Null object).
