### PR TITLE
Setup schema - Automatically creates schemas for SQLAlchemy classes

### DIFF
--- a/marshmallow_sqlalchemy/__init__.py
+++ b/marshmallow_sqlalchemy/__init__.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from .schema import (
     SchemaOpts,
     ModelSchema,
+    setup_schema,
 )
 
 from .convert import (
@@ -27,4 +28,5 @@ __all__ = [
     'column2field',
     'ModelConversionError',
     'field_for',
+    'setup_schema',
 ]

--- a/marshmallow_sqlalchemy/schema.py
+++ b/marshmallow_sqlalchemy/schema.py
@@ -70,7 +70,7 @@ class ModelSchema(with_metaclass(SchemaMeta, ma.Schema)):
 
 def setup_schema(Base, session):
     """Automatically setup Marshmallow schemas. Designed to trigger from
-    SQLAlchemy's 'mapper_configured' event.
+    SQLAlchemy's 'after_configured' event.
 
     Example: ::
 

--- a/marshmallow_sqlalchemy/schema.py
+++ b/marshmallow_sqlalchemy/schema.py
@@ -3,6 +3,7 @@ import marshmallow as ma
 from marshmallow.compat import with_metaclass
 
 from .convert import ModelConverter
+from .exceptions import ModelConversionError
 
 
 class SchemaOpts(ma.SchemaOpts):
@@ -65,3 +66,65 @@ class ModelSchema(with_metaclass(SchemaMeta, ma.Schema)):
 
     def make_object(self, data):
         return self.opts.model(**data)
+
+
+def setup_schema(session):
+    """Automatically setup Marshmallow schemas. Designed to trigger from
+    SQLAlchemy's 'mapper_configured' event.
+
+    Example: ::
+
+        import sqlalchemy as sa
+        from sqlalchemy.ext.declarative import declarative_base
+        from sqlalchemy.orm import scoped_session, sessionmaker
+        from sqlalchemy import event
+        from sqlalchemy.orm import mapper
+        from marshmallow_sqlalchemy import setup_schema
+
+        engine = sa.create_engine('sqlite:///:memory:')
+        session = scoped_session(sessionmaker(bind=engine))
+        Base = declarative_base()
+
+        class Author(Base):
+            __tablename__ = 'authors'
+            id = sa.Column(sa.Integer, primary_key=True)
+            name = sa.Column(sa.String)
+
+            def __repr__(self):
+                return '<Author(name={self.name!r})>'.format(self=self)
+
+        event.listen(mapper, 'mapper_configured', setup_schema(session))
+
+        Base.metadata.create_all(engine)
+
+        author = Author(name='Chuck Paluhniuk')
+        session.add(author)
+        session.commit()
+
+        author_schema = Author.__marshmallow__
+
+        print author_schema.dump(author).data
+
+    """
+    def setup_schema_fn(mapper, class_):
+        if class_.__name__.endswith('Schema'):
+            raise ModelConversionError(
+                "For safety, setup_schema can not be used when a Model class"\
+                "ends with 'Schema'"
+            )
+
+        class Meta(object):
+            model = class_
+            sqla_session = session
+
+        schema_class_name = '%sSchema' % class_.__name__
+
+        schema_class = type(
+            schema_class_name,
+            (ModelSchema,),
+            {'Meta': Meta}
+        )
+
+        setattr(class_, '__marshmallow__', schema_class())
+
+    return setup_schema_fn

--- a/marshmallow_sqlalchemy/schema.py
+++ b/marshmallow_sqlalchemy/schema.py
@@ -111,7 +111,7 @@ def setup_schema(Base, session):
             if hasattr(class_, '__tablename__'):
                 if class_.__name__.endswith('Schema'):
                     raise ModelConversionError(
-                        "For safety, setup_schema can not be used when a"\
+                        "For safety, setup_schema can not be used when a"
                         "Model class ends with 'Schema'"
                     )
 

--- a/marshmallow_sqlalchemy/schema.py
+++ b/marshmallow_sqlalchemy/schema.py
@@ -68,7 +68,7 @@ class ModelSchema(with_metaclass(SchemaMeta, ma.Schema)):
         return self.opts.model(**data)
 
 
-def setup_schema(session):
+def setup_schema(Base, session):
     """Automatically setup Marshmallow schemas. Designed to trigger from
     SQLAlchemy's 'mapper_configured' event.
 
@@ -93,7 +93,7 @@ def setup_schema(session):
             def __repr__(self):
                 return '<Author(name={self.name!r})>'.format(self=self)
 
-        event.listen(mapper, 'mapper_configured', setup_schema(session))
+        event.listen(mapper, 'after_configured', setup_schema(Base, session))
 
         Base.metadata.create_all(engine)
 
@@ -106,25 +106,27 @@ def setup_schema(session):
         print author_schema.dump(author).data
 
     """
-    def setup_schema_fn(mapper, class_):
-        if class_.__name__.endswith('Schema'):
-            raise ModelConversionError(
-                "For safety, setup_schema can not be used when a Model class"\
-                "ends with 'Schema'"
-            )
+    def setup_schema_fn():
+        for class_ in Base._decl_class_registry.values():
+            if hasattr(class_, '__tablename__'):
+                if class_.__name__.endswith('Schema'):
+                    raise ModelConversionError(
+                        "For safety, setup_schema can not be used when a"\
+                        "Model class ends with 'Schema'"
+                    )
 
-        class Meta(object):
-            model = class_
-            sqla_session = session
+                class Meta(object):
+                    model = class_
+                    sqla_session = session
 
-        schema_class_name = '%sSchema' % class_.__name__
+                schema_class_name = '%sSchema' % class_.__name__
 
-        schema_class = type(
-            schema_class_name,
-            (ModelSchema,),
-            {'Meta': Meta}
-        )
+                schema_class = type(
+                    schema_class_name,
+                    (ModelSchema,),
+                    {'Meta': Meta}
+                )
 
-        setattr(class_, '__marshmallow__', schema_class())
+                setattr(class_, '__marshmallow__', schema_class())
 
     return setup_schema_fn


### PR DESCRIPTION
This allows automatic building of schemas for all defined SQLAlchemy classes in a given Base.

Potentially it could be adapted to make use of additional meta information in the classes to customize the behaviour.
