### PR TITLE
Handle uselist=False case for one/many to zero/one case

### DIFF
--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -71,8 +71,10 @@ class ModelConverter(object):
         field_kwargs = self._get_field_kwargs_for_property(prop)
         field_kwargs.update(kwargs)
         ret = field_class(**field_kwargs)
-        if hasattr(prop, 'direction') and self.DIRECTION_MAPPING[prop.direction.name]:
-            ret = fields.List(ret)
+        if (hasattr(prop, 'direction') and
+            self.DIRECTION_MAPPING[prop.direction.name] and
+            prop.uselist is True):
+                ret = fields.List(ret)
         return ret
 
     def column2field(self, column, instance=True, **kwargs):
@@ -157,7 +159,8 @@ class ModelConverter(object):
         nullable = True
         for pair in prop.local_remote_pairs:
             if not pair[0].nullable:
-                nullable = False
+                if prop.uselist is True:
+                    nullable = False
                 break
         kwargs.update({
             'allow_none': nullable,

--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -71,9 +71,9 @@ class ModelConverter(object):
         field_kwargs = self._get_field_kwargs_for_property(prop)
         field_kwargs.update(kwargs)
         ret = field_class(**field_kwargs)
-        if (hasattr(prop, 'direction') and
-            self.DIRECTION_MAPPING[prop.direction.name] and
-            prop.uselist is True):
+        if hasattr(prop, 'direction') and \
+           self.DIRECTION_MAPPING[prop.direction.name] and \
+           prop.uselist is True:
                 ret = fields.List(ret)
         return ret
 


### PR DESCRIPTION
This is an issue when a relationship is specified with `uselist=False` because of how marhsmallow-sqlalchemy determines both:
- If a field is `QuerySelect` or `QuerySelectList`
- If a field is nullable

In this test case, the fact that an author is featured is stored in a separate table. I know that I could simply make `featured` a column of `Author`, but I have a more complicated example where that does not make sense.

``` python
class Author(Base):
    __tablename__ = 'authors'
    id = sa.Column(sa.Integer, primary_key=True)
    name = sa.Column(sa.String)

    featuring = relationship('FeaturedAuthor', uselist=False,
                             backref='author')

    @hybrid_property
    def featured(self):
        if self.featuring is not None:
            return True
        return False

    @featured.expression
    def featured(cls):
        if cls.featuring is not None:
            return True
        return False

    def __repr__(self):
        return '<Author(name={self.name!r})>'.format(self=self)

class FeaturedAuthor(Base):
    __tablename__ = 'featuredauthors'
    id = sa.Column(sa.Integer, sa.ForeignKey('authors.id'), primary_key=True)
```

As `uselist=False` is not being factored into the decision of what field type this should be, a `QuerySelectList` is used where a `QuerySelect` would be appropriate.

Then when deserialising an object, a determination is made based on if the primary key of the first part of the relationship is nullable. In this case, this does not apply so that is special cased as well.

I have added a couple of tests to the suite, but there is also a standalone test example [in this gist](https://gist.github.com/dpwrussell/c74c8ad628cc28d8bc56).

I hope that's useful and I will happily take any suggestions for improvement especially on how I've handed the nullable part which I understand less well.

Cheers
