### PR TITLE
Include overidden by fk field that should be serialized

### DIFF
--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -60,12 +60,11 @@ class ModelConverter(object):
                 if not include_fk:
                     # Only skip a column if there is no overriden column
                     # which does not have a Foreign Key.
-                    all_fk = True
                     for column in prop.columns:
                         if not column.foreign_keys:
                             all_fk = False
                             break
-                    if all_fk is True:
+                    else:
                         continue
             field = self.property2field(prop)
             if field:

--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -62,7 +62,6 @@ class ModelConverter(object):
                     # which does not have a Foreign Key.
                     for column in prop.columns:
                         if not column.foreign_keys:
-                            all_fk = False
                             break
                     else:
                         continue

--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -57,8 +57,16 @@ class ModelConverter(object):
             if fields and prop.key not in fields:
                 continue
             if hasattr(prop, 'columns'):
-                if not include_fk and prop.columns[0].foreign_keys:
-                    continue
+                if not include_fk:
+                    # Only skip a column if there is no overriden column
+                    # which does not have a Foreign Key.
+                    all_fk = True
+                    for column in prop.columns:
+                        if not column.foreign_keys:
+                            all_fk = False
+                            break
+                    if all_fk is True:
+                        continue
             field = self.property2field(prop)
             if field:
                 result[prop.key] = field

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -118,6 +118,30 @@ def models(Base):
         id = sa.Column(sa.Integer, sa.ForeignKey('teacher.id'),
                        primary_key=True)
 
+    class Paper(Base):
+        __tablename__ = 'paper'
+
+        satype = sa.Column(sa.String(50))
+        __mapper_args__ = {
+            'polymorphic_identity': 'paper',
+            'polymorphic_on': satype
+        }
+
+        id = sa.Column(sa.Integer, primary_key=True)
+        name = sa.Column(sa.String, nullable=False, unique=True)
+
+    class GradedPaper(Paper):
+        __tablename__ = 'gradedpaper'
+
+        __mapper_args__ = {
+            'polymorphic_identity': 'gradedpaper'
+        }
+
+        id = sa.Column(sa.Integer, sa.ForeignKey('paper.id'),
+                       primary_key=True)
+
+        marks_available = sa.Column(sa.Integer)
+
     # So that we can access models with dot-notation, e.g. models.Course
     class _models(object):
         def __init__(self):
@@ -126,6 +150,8 @@ def models(Base):
             self.Student = Student
             self.Teacher = Teacher
             self.SubstituteTeacher = SubstituteTeacher
+            self.Paper = Paper
+            self.GradedPaper = GradedPaper
     return _models()
 
 @pytest.fixture()
@@ -153,6 +179,15 @@ def schemas(models, session):
     class SubstituteTeacherSchema(ModelSchema):
         class Meta:
             model = models.SubstituteTeacher
+
+    class PaperSchema(ModelSchema):
+        class Meta:
+            model = models.Paper
+            sqla_session = session
+
+    class GradedPaperSchema(ModelSchema):
+        class Meta:
+            model = models.GradedPaper
             sqla_session = session
 
     class HyperlinkStudentSchema(ModelSchema):
@@ -168,6 +203,8 @@ def schemas(models, session):
             self.StudentSchema = StudentSchema
             self.TeacherSchema = TeacherSchema
             self.SubstituteTeacherSchema = SubstituteTeacherSchema
+            self.PaperSchema = PaperSchema
+            self.GradedPaperSchema = GradedPaperSchema
             self.HyperlinkStudentSchema = HyperlinkStudentSchema
     return _schemas()
 
@@ -226,6 +263,10 @@ class TestModelFieldConversion:
 
         student_fields2 = fields_for_model(models.Student, include_fk=True)
         assert 'current_school_id' in student_fields2
+
+    def test_overridden_with_fk(self, models):
+        graded_paper_fields = fields_for_model(models.GradedPaper)
+        assert 'id' in graded_paper_fields
 
 def make_property(*column_args, **column_kwargs):
     return column_property(sa.Column(*column_args, **column_kwargs))

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -265,7 +265,8 @@ class TestModelFieldConversion:
         assert 'current_school_id' in student_fields2
 
     def test_overridden_with_fk(self, models):
-        graded_paper_fields = fields_for_model(models.GradedPaper)
+        graded_paper_fields = fields_for_model(models.GradedPaper,
+                                               include_fk=False)
         assert 'id' in graded_paper_fields
 
 def make_property(*column_args, **column_kwargs):


### PR DESCRIPTION
When using joined table inheritance this is a common pattern:

``` python
class Person(Base):
    __tablename__ = 'person'

    type = sa.Column(sa.String(50))
    __mapper_args__ = {
        'polymorphic_identity': 'person',
        'polymorphic_on': type
    }

    id = sa.Column(sa.Integer, primary_key=True)
    name = sa.Column(sa.String)

class Author(Person):
    __tablename__ = 'authors'

    __mapper_args__ = {
        'polymorphic_identity': 'author'
    }

    id = sa.Column(sa.Integer, sa.ForeignKey('person.id'), primary_key=True)
    featured = sa.Column(sa.Boolean)
```

`id` is overridden and in the sub-class will always have the `ForeignKey` to the immediate super-class. This means that when determining which fields to include in the model serialization for `Author`, `id` is skipped. It looks like this:

``` python
{'featured': None, 'books': [1], 'type': u'author', 'name': u'Chuck Paluhniuk'}
```

If I was to serialize this with the `PersonSchema` then the result would be:

``` python
{'type': u'author', 'id': 1, 'name': u'Chuck Paluhniuk'}
```

which does include the id.

It is of course possible to specify `include_fk=True`, but I believe the reason that this exists is so that where there are relationships these are shown instead of the ids. It definitely does not make sense to have a relationship defined between `Author.id` and `Person.id`.

I think it would make sense in this situation for the overridden field to be included in the serialization and this can be easily determined by simply checking all the corresponding columns instead of [just the first one](https://github.com/marshmallow-code/marshmallow-sqlalchemy/blob/dev/marshmallow_sqlalchemy/convert.py#L60).

I have added a unit test to make sure this field is serialized where appropriate and the [existing test](https://github.com/marshmallow-code/marshmallow-sqlalchemy/blob/dev/tests/test_marshmallow_sqlalchemy.py#L223) already makes sure that this does not apply to regular columns with foreign keys.

The above example would now serialize like so:

``` python
{'featured': None, 'books': [1], 'type': u'author', 'id': 1, 'name': u'Chuck Paluhniuk'}
```

Cheers
