### PR TITLE
Customization of fields by specifying info

### DIFF
--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -185,6 +185,7 @@ class ModelConverter(object):
             self._add_column_info_kwargs(kwargs, prop.columns)
         if hasattr(prop, 'direction'):  # Relationship property
             self._add_relationship_kwargs(kwargs, prop)
+            self._add_relationship_info_kwargs(kwargs, prop)
         if getattr(prop, 'doc', None):  # Useful for documentation generation
             kwargs['description'] = prop.doc
         return kwargs
@@ -231,6 +232,16 @@ class ModelConverter(object):
         for column in reversed(columns):
             if 'marshmallow_sqlalchemy' in column.info:
                 kwargs.update(column.info['marshmallow_sqlalchemy'])
+
+    def _add_relationship_info_kwargs(self, kwargs, prop):
+        """Add keyword arguments to kwargs (in-place) based on the passed in
+        `marshmallow_sqlalchemy` dictionary.
+        """
+        # Process any passed in settings in reverse order as the columns are
+        # in sub to super class order
+
+        if 'marshmallow_sqlalchemy' in prop.info:
+            kwargs.update(prop.info['marshmallow_sqlalchemy'])
 
     def get_base_kwargs(self):
         return {

--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -182,6 +182,7 @@ class ModelConverter(object):
         if hasattr(prop, 'columns'):
             column = prop.columns[0]
             self._add_column_kwargs(kwargs, column)
+            self._add_column_info_kwargs(kwargs, prop.columns)
         if hasattr(prop, 'direction'):  # Relationship property
             self._add_relationship_kwargs(kwargs, prop)
         if getattr(prop, 'doc', None):  # Useful for documentation generation
@@ -220,6 +221,16 @@ class ModelConverter(object):
             'allow_none': nullable,
             'required': not nullable,
         })
+
+    def _add_column_info_kwargs(self, kwargs, columns):
+        """Add keyword arguments to kwargs (in-place) based on the passed in
+        `marshmallow_sqlalchemy` dictionary.
+        """
+        # Process any passed in settings in reverse order as the columns are
+        # in sub to super class order
+        for column in reversed(columns):
+            if 'marshmallow_sqlalchemy' in column.info:
+                kwargs.update(column.info['marshmallow_sqlalchemy'])
 
     def get_base_kwargs(self):
         return {

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -131,6 +131,15 @@ def models(Base):
         id = sa.Column(sa.Integer, primary_key=True)
         name = sa.Column(sa.String, nullable=False, unique=True)
 
+        # Description field, not to be serialized
+        description = sa.Column(
+            sa.String,
+            info={
+                'marshmallow_sqlalchemy': {
+                    'load_only': True
+                 }
+            })
+
     class GradedPaper(Paper):
         __tablename__ = 'gradedpaper'
 
@@ -324,6 +333,14 @@ class TestModelFieldConversion:
         graded_paper_fields = fields_for_model(models.GradedPaper,
                                                include_fk=False)
         assert 'id' in graded_paper_fields
+
+    def test_info_customization(self, models):
+        paper_fields = fields_for_model(models.Paper)
+        assert paper_fields['description'].load_only is True
+
+    def test_info_customization_super(self, models):
+        graded_paper_fields = fields_for_model(models.GradedPaper)
+        assert graded_paper_fields['description'].load_only is True
 
 def make_property(*column_args, **column_kwargs):
     return column_property(sa.Column(*column_args, **column_kwargs))

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -140,6 +140,17 @@ def models(Base):
                  }
             })
 
+        course_id = sa.Column(sa.Integer, sa.ForeignKey('course.id'))
+        # Course relationship, not to be serialized
+        course = relationship(
+            Course,
+            info={
+                'marshmallow_sqlalchemy': {
+                    'load_only': True
+                 }
+            }
+        )
+
     class GradedPaper(Paper):
         __tablename__ = 'gradedpaper'
 
@@ -334,13 +345,21 @@ class TestModelFieldConversion:
                                                include_fk=False)
         assert 'id' in graded_paper_fields
 
-    def test_info_customization(self, models):
+    def test_property_info_customization(self, models):
         paper_fields = fields_for_model(models.Paper)
         assert paper_fields['description'].load_only is True
 
-    def test_info_customization_super(self, models):
+    def test_property_info_customization_super(self, models):
         graded_paper_fields = fields_for_model(models.GradedPaper)
         assert graded_paper_fields['description'].load_only is True
+
+    def test_relationship_info_customization(self, models):
+        paper_fields = fields_for_model(models.Paper)
+        assert paper_fields['course'].load_only is True
+
+    def test_relationship_info_customization_super(self, models):
+        graded_paper_fields = fields_for_model(models.GradedPaper)
+        assert graded_paper_fields['course'].load_only is True
 
 def make_property(*column_args, **column_kwargs):
     return column_property(sa.Column(*column_args, **column_kwargs))

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -290,9 +290,11 @@ def models_schemas_inter(Base, models, schemas, session):
             sa.Integer,
             info={
                 'marshmallow_sqlalchemy': {
-                    'field': fields.Decimal()
-                 }
-            }
+                    'field': fields.Decimal(),
+                    'load_only': True
+                }
+            },
+            nullable=True
         )
 
         student_id = sa.Column(sa.Integer, sa.ForeignKey('student.id'),
@@ -302,7 +304,7 @@ def models_schemas_inter(Base, models, schemas, session):
             info={
                 'marshmallow_sqlalchemy': {
                     'field': fields.Nested(schemas.StudentSchema)
-                 }
+                }
             }
         )
 
@@ -403,6 +405,8 @@ class TestModelFieldConversion:
     def test_property_info_field_customization(self, models_schemas_inter):
         locker_fields = fields_for_model(models_schemas_inter.Locker)
         assert type(locker_fields['capacity']) is fields.Decimal
+        assert locker_fields['capacity'].load_only is True
+        assert locker_fields['capacity'].allow_none is True
 
     def test_relationship_info_field_customization(self, models_schemas_inter):
         locker_fields = fields_for_model(models_schemas_inter.Locker)


### PR DESCRIPTION
Note: This is a work in progress, but I'm filing it as a PR to get input.

Begins to address #21

Enable customization of a column property by specifying `info['marshmallow_sqlalchemy]`.

``` python
        description = sa.Column(
            sa.String,
            info={
                'marshmallow_sqlalchemy': {
                    'load_only': True
                 }
            })
```

This will affect the model that has this column, and any models that inherit from that. If a field is repeated in the child (normally the primary and foreign key used in joined table inheritance) then an `info['marshmallow_sqlalchemy`]`block specified on a sub-class can override one specified on a super-class.

This makes use of `info`, and this is [its designated purpose](http://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.Column.info).

Update: Also deals with relationships in the same fashion.

Update2: Will now accept a special `field` key to specify the marshmallow field type. I am a lot less certain about how to implement this functionality. Currently it only works for properties and as it takes a type rather than an instance, `fields.List` or `fields.Nested` will not work. Perhaps it should take an instance instead? Input welcome.

Update3: It now uses an instance instead of a type for the `field`. It works on both `Columns` and `relationships.`

``` python
        capacity = sa.Column(
            sa.Integer,
            info={
                'marshmallow_sqlalchemy': {
                    'field': fields.Decimal()
                 }
            }
        )

        student_id = sa.Column(sa.Integer, sa.ForeignKey('student.id'),
                               nullable=False, unique=True)
        student = relationship(
            models.Student,
            info={
                'marshmallow_sqlalchemy': {
                    'field': fields.Nested(schemas.StudentSchema)
                 }
            }
        )
```
