### PR TITLE
Handle columns that don't implement python_type.

### DIFF
--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -132,8 +132,12 @@ class ModelConverter(object):
                 break
         else:
             # Try to find a field class based on the column's python_type
-            if data_type.python_type in ma.Schema.TYPE_MAPPING:
-                field_cls = ma.Schema.TYPE_MAPPING[data_type.python_type]
+            try:
+                python_type = data_type.python_type
+            except NotImplementedError:
+                python_type = None
+            if python_type in ma.Schema.TYPE_MAPPING:
+                field_cls = ma.Schema.TYPE_MAPPING[python_type]
             else:
                 raise ModelConversionError(
                     'Could not find field column of type {0}.'.format(types[0]))

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -13,7 +13,7 @@ from marshmallow import fields, validate, post_load
 import pytest
 from marshmallow_sqlalchemy import (
     fields_for_model, TableSchema, ModelSchema, ModelConverter, property2field, column2field,
-    field_for,
+    field_for, ModelConversionError
 )
 from marshmallow_sqlalchemy.fields import Related
 
@@ -371,6 +371,11 @@ class TestPropertyFieldConversion:
         field = converter.property2field(prop)
         assert type(field) == fields.List
         assert type(field.container) == fields.Int
+
+    def test_convert_TSVECTOR(self, converter):
+        prop = make_property(postgresql.TSVECTOR)
+        with pytest.raises(ModelConversionError):
+            converter.property2field(prop)
 
 class TestPropToFieldClass:
 


### PR DESCRIPTION
Some columns, such as `postgresql.TSVECTOR`, don't implement
`python_type`, such that accessing the latter raises
`NotImplementedError`. This patch catches the error so that attempting
to convert these columns throws a more interpretable
`ModelConversionError`.
