### PR TITLE
Add interface to update existing rows.

### DIFF
--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -179,10 +179,6 @@ class ModelConverter(object):
         if hasattr(column.type, 'scale'):
             kwargs['places'] = getattr(column.type, 'scale', None)
 
-        # Primary keys are dump_only ("read-only")
-        if getattr(column, 'primary_key', False):
-            kwargs['dump_only'] = True
-
     def _add_relationship_kwargs(self, kwargs, prop):
         """Add keyword arguments to kwargs (in-place) based on the passed in
         relationship `Property`.

--- a/marshmallow_sqlalchemy/schema.py
+++ b/marshmallow_sqlalchemy/schema.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import marshmallow as ma
-from marshmallow.compat import with_metaclass
+from marshmallow.compat import with_metaclass, iteritems
 
 from .convert import ModelConverter
 from .fields import get_primary_column
@@ -146,7 +146,8 @@ class ModelSchema(with_metaclass(ModelSchemaMeta, ma.Schema)):
         """
         instance = self.instance or self.get_instance(data)
         if instance is not None:
-            instance.__dict__.update(data)
+            for key, value in iteritems(data):
+                setattr(instance, key, value)
             return instance
         return self.opts.model(**data)
 


### PR DESCRIPTION
Currently, primary keys are set to dump but not load, such that
deserializing always creates a new object. This patch changes the
default behavior, such that we attempt to load by primary key on
deserialization, and update the returned object if found. This default
can also be overridden by passing `instance` to either a `ModelSchema`
constructor, or to its `load` method; updates will then be applied to
`instance`, and deserializing will not attempt to load records from the
database.
