### PR TITLE
Support compound primary keys.

### DIFF
--- a/marshmallow_sqlalchemy/fields.py
+++ b/marshmallow_sqlalchemy/fields.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from marshmallow import fields
+from marshmallow.utils import is_iterable_but_not_string
 
 
 def get_primary_columns(model):
@@ -11,7 +12,7 @@ def get_primary_columns(model):
     return model.__mapper__.primary_key
 
 def ensure_list(value):
-    return value if isinstance(value, list) else [value]
+    return value if is_iterable_but_not_string(value) else [value]
 
 class Related(fields.Field):
     """Related data represented by a SQLAlchemy `relationship`. Must be attached

--- a/marshmallow_sqlalchemy/fields.py
+++ b/marshmallow_sqlalchemy/fields.py
@@ -3,30 +3,28 @@
 from marshmallow import fields
 
 
-def get_primary_column(model):
-    """Get primary key column for a SQLAlchemy model.
+def get_primary_columns(model):
+    """Get primary key columns for a SQLAlchemy model.
 
     :param model: SQLAlchemy model class
-    :raise: RuntimeError if model has multiple primary key columns
     """
-    columns = model.__mapper__.primary_key
-    if len(columns) == 1:
-        return columns[0]
-    raise RuntimeError('Model {0!r} has multiple primary keys'.format(model))
+    return model.__mapper__.primary_key
 
+def ensure_list(value):
+    return value if isinstance(value, list) else [value]
 
 class Related(fields.Field):
     """Related data represented by a SQLAlchemy `relationship`. Must be attached
     to a :class:`Schema` class whose options includes a SQLAlchemy `model`, such
     as :class:`ModelSchema`.
 
-    :param str column: Optional column name on related model. If not provided,
-        the primary key of the related model will be used.
+    :param list columns: Optional column names on related model. If not provided,
+        the primary key(s) of the related model will be used.
     """
 
     def __init__(self, column=None, **kwargs):
         super(Related, self).__init__(**kwargs)
-        self.column = column
+        self.columns = ensure_list(column or [])
 
     @property
     def model(self):
@@ -37,21 +35,29 @@ class Related(fields.Field):
         return getattr(self.model, self.attribute or self.name).property.mapper.class_
 
     @property
-    def related_column(self):
-        if self.column:
-            return self.related_model.__mapper__.columns[self.column]
-        return get_primary_column(self.related_model)
+    def related_columns(self):
+        if self.columns:
+            return [
+                self.related_model.__mapper__.columns[column]
+                for column in self.columns
+            ]
+        return get_primary_columns(self.related_model)
 
     @property
     def session(self):
         return self.parent.session
 
     def _serialize(self, value, attr, obj):
-        return getattr(value, self.related_column.key, None)
+        ret = [
+            getattr(value, column.key, None)
+            for column in self.related_columns
+        ]
+        return ret if len(ret) > 1 else ret[0]
 
     def _deserialize(self, value, *args, **kwargs):
         return self.session.query(
             self.related_model
-        ).filter(
-            self.related_column == value
-        ).one()
+        ).filter_by(**{
+            column.key: datum
+            for column, datum in zip(self.related_columns, ensure_list(value))
+        }).one()

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -581,10 +581,20 @@ class TestModelSchema:
     def test_model_schema_compound_key_relationship(self, schemas, lecture):
         schema = schemas.LectureSchema()
         dump_data = schema.dump(lecture).data
-        assert dump_data['seminar'] == [lecture.seminar_title, lecture.seminar_semester]
+        assert dump_data['seminar'] == {
+            'title': lecture.seminar_title,
+            'semester': lecture.seminar_semester,
+        }
         result = schema.load(dump_data)
 
         assert result.data is lecture
+
+    def test_model_schema_compound_key_relationship_invalid_key(self, schemas, lecture):
+        schema = schemas.LectureSchema()
+        dump_data = schema.dump(lecture).data
+        dump_data['seminar'] = 'scalar'
+        with pytest.raises(ValueError):
+            schema.load(dump_data)
 
     def test_model_schema_loading_passing_session_to_load(self, models, schemas, student, session):
         class StudentSchemaNoSession(ModelSchema):


### PR DESCRIPTION
For models with multiple primary keys, deserialize using all primary
keys. For relationships on multiple foreign keys, serialize and
deserialize as a list of foreign key values.

Note: this patch serializes relationships with multiple foreign keys as lists, but we could also use dictionaries. We also continue to serialize single primary keys as scalars for simplicity, but it would arguably be more consistent to always return the same data structure.
