### PR TITLE
Include mssql dilect BIT field support.

### DIFF
--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -4,7 +4,7 @@ import functools
 
 import marshmallow as ma
 from marshmallow import validate, fields
-from sqlalchemy.dialects import postgresql, mysql
+from sqlalchemy.dialects import postgresql, mysql, mssql
 import sqlalchemy as sa
 
 from .exceptions import ModelConversionError
@@ -50,6 +50,8 @@ class ModelConverter(object):
         mysql.YEAR: fields.Integer,
         mysql.SET: fields.List,
         mysql.ENUM: fields.Field,
+
+        mysql.BIT: fields.Integer,
     }
 
     DIRECTION_MAPPING = {

--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -51,7 +51,7 @@ class ModelConverter(object):
         mysql.SET: fields.List,
         mysql.ENUM: fields.Field,
 
-        mysql.BIT: fields.Integer,
+        mssql.BIT: fields.Integer,
     }
 
     DIRECTION_MAPPING = {


### PR DESCRIPTION
Without inclusion of BIT field support for mssql dialect I can't use models automatically created from legacy mssql database.

This path is a simple addition of mssql.BIT to convert list.
