### PR TITLE
Use property names rather than column names for primary keys.

### DIFF
--- a/marshmallow_sqlalchemy/fields.py
+++ b/marshmallow_sqlalchemy/fields.py
@@ -4,12 +4,16 @@ from marshmallow import fields
 from marshmallow.utils import is_iterable_but_not_string
 
 
-def get_primary_columns(model):
-    """Get primary key columns for a SQLAlchemy model.
+def get_primary_keys(model):
+    """Get primary key properties for a SQLAlchemy model.
 
     :param model: SQLAlchemy model class
     """
-    return model.__mapper__.primary_key
+    mapper = model.__mapper__
+    return [
+        mapper.get_property_by_column(column)
+        for column in mapper.primary_key
+    ]
 
 def get_schema_for_field(field):
     if hasattr(field, 'root'):  # marshmallow>=2.1
@@ -43,13 +47,13 @@ class Related(fields.Field):
         return getattr(self.model, self.attribute or self.name).property.mapper.class_
 
     @property
-    def related_columns(self):
+    def related_keys(self):
         if self.columns:
             return [
                 self.related_model.__mapper__.columns[column]
                 for column in self.columns
             ]
-        return get_primary_columns(self.related_model)
+        return get_primary_keys(self.related_model)
 
     @property
     def session(self):
@@ -58,25 +62,25 @@ class Related(fields.Field):
 
     def _serialize(self, value, attr, obj):
         ret = {
-            column.key: getattr(value, column.key, None)
-            for column in self.related_columns
+            prop.key: getattr(value, prop.key, None)
+            for prop in self.related_keys
         }
         return ret if len(ret) > 1 else list(ret.values())[0]
 
     def _deserialize(self, value, *args, **kwargs):
         if not isinstance(value, dict):
-            if len(self.related_columns) != 1:
+            if len(self.related_keys) != 1:
                 raise ValueError(
                     'Could not deserialized related value {0!r}; expected a dictionary '
                     'with keys {1!r}'.format(
                         value,
-                        [column.key for column in self.related_columns]
+                        [prop.key for prop in self.related_keys]
                     )
                 )
-            value = {self.related_columns[0].key: value}
+            value = {self.related_keys[0].key: value}
         return self.session.query(
             self.related_model
         ).filter_by(**{
-            column.key: value.get(column.key)
-            for column in self.related_columns
+            prop.key: value.get(prop.key)
+            for prop in self.related_keys
         }).one()

--- a/marshmallow_sqlalchemy/schema.py
+++ b/marshmallow_sqlalchemy/schema.py
@@ -3,7 +3,7 @@ import marshmallow as ma
 from marshmallow.compat import with_metaclass, iteritems
 
 from .convert import ModelConverter
-from .fields import get_primary_columns
+from .fields import get_primary_keys
 
 
 class TableSchemaOpts(ma.SchemaOpts):
@@ -141,10 +141,10 @@ class ModelSchema(with_metaclass(ModelSchemaMeta, ma.Schema)):
 
     def get_instance(self, data):
         """Retrieve an existing record by primary key(s)."""
-        columns = get_primary_columns(self.opts.model)
+        props = get_primary_keys(self.opts.model)
         filters = {
-            column.key: data.get(column.key)
-            for column in columns
+            prop.key: data.get(prop.key)
+            for prop in props
         }
         if None not in filters.values():
             return self.session.query(

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -73,7 +73,7 @@ def models(Base):
 
     class School(Base):
         __tablename__ = 'school'
-        id = sa.Column(sa.Integer, primary_key=True)
+        id = sa.Column('school_id', sa.Integer, primary_key=True)
         name = sa.Column(sa.String(255), nullable=False)
 
         @property
@@ -465,7 +465,7 @@ class TestTableSchema:
                 table = models.School.__table__
         schema = SchoolSchema()
         dump = schema.dump(school).data
-        assert dump == {'name': 'Univ. of Whales', 'id': 1}
+        assert dump == {'name': 'Univ. of Whales', 'school_id': 1}
 
 class TestModelSchema:
 
@@ -830,4 +830,4 @@ class TestNullForeignKey:
 
         assert type(result.data) is models.Teacher
         assert 'substitute' in data
-        assert data['substitute'] == None
+        assert data['substitute'] is None


### PR DESCRIPTION
When model properties and table columns have different names, use the
property name rather than the column name. This resolves a bug on
serializing relationships whose primary key columns are aliased to
different names reported by @repole.

[Resolves #44]
