### PR TITLE
Respect a Schema class's TYPE_MAPPING

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 ---------
 
+0.8.0 (unreleased)
+++++++++++++++++++
+
+Features:
+
+- ``ModelSchema`` and ``TableSchema`` will respect the ``TYPE_MAPPING`` class variable of Schema subclasses when converting ``Columns`` to ``Fields`` (:issue:`42`). Thanks :user:`dwieeb` for the suggestion.
+
 0.7.1 (2015-12-13)
 ++++++++++++++++++
 

--- a/marshmallow_sqlalchemy/__init__.py
+++ b/marshmallow_sqlalchemy/__init__.py
@@ -17,7 +17,7 @@ from .convert import (
 )
 from .exceptions import ModelConversionError
 
-__version__ = '0.7.1'
+__version__ = '0.8.0.dev0'
 __license__ = 'MIT'
 
 __all__ = [

--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -76,6 +76,13 @@ class ModelConverter(object):
     def __init__(self, schema_cls=None):
         self.schema_cls = schema_cls
 
+    @property
+    def type_mapping(self):
+        if self.schema_cls:
+            return self.schema_cls.TYPE_MAPPING
+        else:
+            return ma.Schema.TYPE_MAPPING
+
     def fields_for_model(self, model, include_fk=False, fields=None, exclude=None):
         result = {}
         for prop in model.__mapper__.iterate_properties:
@@ -155,14 +162,8 @@ class ModelConverter(object):
             except NotImplementedError:
                 python_type = None
 
-            schema_type_mapping = None
-            if self.schema_cls:
-                schema_type_mapping = self.schema_cls.TYPE_MAPPING
-            else:
-                schema_type_mapping = ma.Schema.TYPE_MAPPING
-
-            if python_type in schema_type_mapping:
-                field_cls = schema_type_mapping[python_type]
+            if python_type in self.type_mapping:
+                field_cls = self.type_mapping[python_type]
             else:
                 raise ModelConversionError(
                     'Could not find field column of type {0}.'.format(types[0]))

--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -73,6 +73,9 @@ class ModelConverter(object):
         'ONETOMANY': True,
     }
 
+    def __init__(self, schema_cls=None):
+        self.schema_cls = schema_cls
+
     def fields_for_model(self, model, include_fk=False, fields=None, exclude=None):
         result = {}
         for prop in model.__mapper__.iterate_properties:
@@ -151,8 +154,15 @@ class ModelConverter(object):
                 python_type = data_type.python_type
             except NotImplementedError:
                 python_type = None
-            if python_type in ma.Schema.TYPE_MAPPING:
-                field_cls = ma.Schema.TYPE_MAPPING[python_type]
+
+            schema_type_mapping = None
+            if self.schema_cls:
+                schema_type_mapping = self.schema_cls.TYPE_MAPPING
+            else:
+                schema_type_mapping = ma.Schema.TYPE_MAPPING
+
+            if python_type in schema_type_mapping:
+                field_cls = schema_type_mapping[python_type]
             else:
                 raise ModelConversionError(
                     'Could not find field column of type {0}.'.format(types[0]))

--- a/marshmallow_sqlalchemy/schema.py
+++ b/marshmallow_sqlalchemy/schema.py
@@ -53,7 +53,7 @@ class SchemaMeta(ma.schema.SchemaMeta):
         declared_fields = kwargs.get('dict_class', dict)()
         opts = klass.opts
         Converter = opts.model_converter
-        converter = Converter()
+        converter = Converter(schema_cls=klass)
         declared_fields = mcs.get_fields(converter, opts)
         base_fields = super(SchemaMeta, mcs).get_declared_fields(
             klass, *args, **kwargs


### PR DESCRIPTION
Allows Schema subclasses to override TYPE_MAPPING. ModelConverter
will respect the TYPE_MAPPINg of the schema class passed to
its constructor

[resolves #42]
