### PR TITLE
Respect ordered meta option.

### DIFF
--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -83,8 +83,8 @@ class ModelConverter(object):
         else:
             return ma.Schema.TYPE_MAPPING
 
-    def fields_for_model(self, model, include_fk=False, fields=None, exclude=None):
-        result = {}
+    def fields_for_model(self, model, include_fk=False, fields=None, exclude=None, dict_cls=dict):
+        result = dict_cls()
         for prop in model.__mapper__.iterate_properties:
             if _should_exclude_field(prop, fields=fields, exclude=exclude):
                 continue
@@ -102,8 +102,8 @@ class ModelConverter(object):
                 result[prop.key] = field
         return result
 
-    def fields_for_table(self, table, include_fk=False, fields=None, exclude=None):
-        result = {}
+    def fields_for_table(self, table, include_fk=False, fields=None, exclude=None, dict_cls=dict):
+        result = dict_cls()
         for column in table.columns:
             if _should_exclude_field(column, fields=fields, exclude=exclude):
                 continue

--- a/marshmallow_sqlalchemy/schema.py
+++ b/marshmallow_sqlalchemy/schema.py
@@ -46,17 +46,17 @@ class SchemaMeta(ma.schema.SchemaMeta):
 
     # override SchemaMeta
     @classmethod
-    def get_declared_fields(mcs, klass, *args, **kwargs):
+    def get_declared_fields(mcs, klass, cls_fields, inherited_fields, dict_cls):
         """Updates declared fields with fields converted from the SQLAlchemy model
         passed as the `model` class Meta option.
         """
-        declared_fields = kwargs.get('dict_class', dict)()
+        declared_fields = dict_cls()
         opts = klass.opts
         Converter = opts.model_converter
         converter = Converter(schema_cls=klass)
-        declared_fields = mcs.get_fields(converter, opts)
+        declared_fields = mcs.get_fields(converter, opts, dict_cls)
         base_fields = super(SchemaMeta, mcs).get_declared_fields(
-            klass, *args, **kwargs
+            klass, cls_fields, inherited_fields, dict_cls
         )
         declared_fields.update(base_fields)
         return declared_fields
@@ -68,28 +68,30 @@ class SchemaMeta(ma.schema.SchemaMeta):
 class TableSchemaMeta(SchemaMeta):
 
     @classmethod
-    def get_fields(mcs, converter, opts):
+    def get_fields(mcs, converter, opts, dict_cls):
         if opts.table is not None:
             return converter.fields_for_table(
                 opts.table,
                 fields=opts.fields,
                 exclude=opts.exclude,
                 include_fk=opts.include_fk,
+                dict_cls=dict_cls,
             )
-        return {}
+        return dict_cls()
 
 class ModelSchemaMeta(SchemaMeta):
 
     @classmethod
-    def get_fields(mcs, converter, opts):
+    def get_fields(mcs, converter, opts, dict_cls):
         if opts.model is not None:
             return converter.fields_for_model(
                 opts.model,
                 fields=opts.fields,
                 exclude=opts.exclude,
                 include_fk=opts.include_fk,
+                dict_cls=dict_cls,
             )
-        return {}
+        return dict_cls()
 
 class TableSchema(with_metaclass(TableSchemaMeta, ma.Schema)):
     """Base class for SQLAlchemy model-based Schemas.

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import sessionmaker, relationship, backref, column_property
 from sqlalchemy.dialects import postgresql
 
 from marshmallow import Schema, fields, validate, post_load
+from marshmallow.compat import OrderedDict
 
 import pytest
 from marshmallow_sqlalchemy import (
@@ -587,6 +588,17 @@ class TestModelSchema:
         assert 'id' in field_names
         assert 'name' in field_names
         assert 'cost' in field_names
+
+    def test_model_schema_ordered(self, models):
+        class SchoolSchema(ModelSchema):
+            class Meta:
+                model = models.School
+                ordered = True
+
+        schema = SchoolSchema()
+        assert isinstance(schema.fields, OrderedDict)
+        fields = [prop.key for prop in models.School.__mapper__.iterate_properties]
+        assert list(schema.fields.keys()) == fields
 
     def test_model_schema_dumping(self, schemas, student):
         schema = schemas.StudentSchema()


### PR DESCRIPTION
[Resolves #52]

@sloria: I was thinking of changing `fields_for_table` and `fields_for_model` to be generators yielding tuples of `(key, field)`, but figured it would be better to pass through `dict_cls` and preserve the signatures of those methods, just in case anybody's depending on them to return dict-like values. Probably not the most important decision.
