### PR TITLE
Skip introspection on defined fields.

### DIFF
--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -83,8 +83,10 @@ class ModelConverter(object):
         else:
             return ma.Schema.TYPE_MAPPING
 
-    def fields_for_model(self, model, include_fk=False, fields=None, exclude=None, dict_cls=dict):
+    def fields_for_model(self, model, include_fk=False, fields=None, exclude=None, base_fields=None,
+                         dict_cls=dict):
         result = dict_cls()
+        base_fields = base_fields or {}
         for prop in model.__mapper__.iterate_properties:
             if _should_exclude_field(prop, fields=fields, exclude=exclude):
                 continue
@@ -97,19 +99,21 @@ class ModelConverter(object):
                             break
                     else:
                         continue
-            field = self.property2field(prop)
+            field = base_fields.get(prop.key) or self.property2field(prop)
             if field:
                 result[prop.key] = field
         return result
 
-    def fields_for_table(self, table, include_fk=False, fields=None, exclude=None, dict_cls=dict):
+    def fields_for_table(self, table, include_fk=False, fields=None, exclude=None, base_fields=None,
+                         dict_cls=dict):
         result = dict_cls()
+        base_fields = base_fields or {}
         for column in table.columns:
             if _should_exclude_field(column, fields=fields, exclude=exclude):
                 continue
             if not include_fk and column.foreign_keys:
                 continue
-            field = self.column2field(column)
+            field = base_fields.get(column.key) or self.column2field(column)
             if field:
                 result[column.key] = field
         return result

--- a/marshmallow_sqlalchemy/schema.py
+++ b/marshmallow_sqlalchemy/schema.py
@@ -54,27 +54,28 @@ class SchemaMeta(ma.schema.SchemaMeta):
         opts = klass.opts
         Converter = opts.model_converter
         converter = Converter(schema_cls=klass)
-        declared_fields = mcs.get_fields(converter, opts, dict_cls)
         base_fields = super(SchemaMeta, mcs).get_declared_fields(
             klass, cls_fields, inherited_fields, dict_cls
         )
+        declared_fields = mcs.get_fields(converter, opts, base_fields, dict_cls)
         declared_fields.update(base_fields)
         return declared_fields
 
     @classmethod
-    def get_fields(mcs, converter, opts):
+    def get_fields(mcs, converter, base_fields, opts):
         pass
 
 class TableSchemaMeta(SchemaMeta):
 
     @classmethod
-    def get_fields(mcs, converter, opts, dict_cls):
+    def get_fields(mcs, converter, opts, base_fields, dict_cls):
         if opts.table is not None:
             return converter.fields_for_table(
                 opts.table,
                 fields=opts.fields,
                 exclude=opts.exclude,
                 include_fk=opts.include_fk,
+                base_fields=base_fields,
                 dict_cls=dict_cls,
             )
         return dict_cls()
@@ -82,13 +83,14 @@ class TableSchemaMeta(SchemaMeta):
 class ModelSchemaMeta(SchemaMeta):
 
     @classmethod
-    def get_fields(mcs, converter, opts, dict_cls):
+    def get_fields(mcs, converter, opts, base_fields, dict_cls):
         if opts.model is not None:
             return converter.fields_for_model(
                 opts.model,
                 fields=opts.fields,
                 exclude=opts.exclude,
                 include_fk=opts.include_fk,
+                base_fields=base_fields,
                 dict_cls=dict_cls,
             )
         return dict_cls()

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -149,6 +149,8 @@ def models(Base):
         title = sa.Column(sa.String, primary_key=True)
         semester = sa.Column(sa.String, primary_key=True)
 
+        label = column_property(title + ': ' + semester)
+
     class Lecture(Base):
         __tablename__ = 'lecture'
         __table_args__ = (
@@ -236,6 +238,7 @@ def schemas(models, session):
         class Meta:
             model = models.Seminar
             sqla_session = session
+        label = fields.Str()
 
     class LectureSchema(ModelSchema):
         class Meta:


### PR DESCRIPTION
Some SQLAlchemy columns can't currently be introspected by
marshmallow-sqlalchemy, or can't be introspected in principle. For
example, columns defined using mapped SQL expressions (using
`column_property` or `object_session`) don't have types and don't define
a `nullable` attribute. In these rare cases, users may want to set
custom fields in their schemas. But this isn't currently possible, since
we raise a `ModelConversionError` when we encounter a column we can't
introspect. This patch skips introspection when the user has explicitly
defined a field in the schema.

Alternatively, we could map `NullType` to `Raw` in `SQLA_TYPE_MAPPING`
and handle properties that don't define `nullable`, which would allow
users to work with mapped expressions without schema field overrides. I
slightly prefer this approach, since it's a bit more flexible, and
because I don't think it's a bad thing for users to explicitly define
types of mapped expressions.

Probably too much discussion for a rare edge case. Thoughts @sloria?
