### PR TITLE
introduced 'many' for Related

### DIFF
--- a/marshmallow_sqlalchemy/schema.py
+++ b/marshmallow_sqlalchemy/schema.py
@@ -168,9 +168,10 @@ class ModelSchema(with_metaclass(ModelSchemaMeta, ma.Schema)):
         """
         instance = self.instance or self.get_instance(data)
         if instance is not None:
-            for key, value in iteritems(data):
-                setattr(instance, key, value)
-            return instance
+            with self.session.no_autoflush:
+                for key, value in iteritems(data):
+                    setattr(instance, key, value)
+                return instance
         return self.opts.model(**data)
 
     def load(self, data, session=None, instance=None, *args, **kwargs):


### PR DESCRIPTION
This allows to set `Related` fields to `many=True` just like with `Nested` fields. It has the nice effect that you can marry those getting a nested field that renders a nested object from the database and can also save it back.
