### PR TITLE
Enable Deserialization of Many-to-One Nested Objects that DNE in DB 

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,3 +15,4 @@ Contributors
 - Jason Mitchell `@mitchej123 <https://github.com/mitchej123>`_
 - Douglas Russell `@dpwrussell <https://github.com/dpwrussell>`_
 - Rudá Porto Filgueiras `@rudaporto <https://github.com/rudaporto>`_
+- Sean Harrington `@seanharr11 <https://github.com/seanharr11>`_


### PR DESCRIPTION
**Proposition:** Given '_One_' object composed of nested fields, with each
nested field containing '_Many_' objects, on deserialization instantiate
each nested object into an instance of the nested field's SQLAlchemy
Model if it does not already exist in the DB.

Current behavior is to fail ungracefully & non-verbosely if a nested
object DNE in DB. The "_NoResultFound_" exception is raised by
"Query.one()".

A sample problem-case is as follows: 

i.) A POST request is sent to a server, and contains a JSON object which contains both parent, and children which do not yet exist on the DB.

``` javascript
author_dict = {'name': 'Robert Jordan', books: 
                             [{'title': 'The Eye of the World'}, 
                              {'title': 'A Memory of Light'}]}
```

ii.) This object is deserialized with a (required) session object, and because the 2 books (in the collection of 'books' above) do not yet exist in the DB, an exception gets thrown when they are retrieved.

``` javascript
author_obj = author_schema.load(author_dict, session).data
```

Without the 'books', the author object can be deserialized even though it has not yet been created on the DB. The proposed feature would keep this consistent across many-to-one nested objects.
