### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,9 @@ marshmallow-sqlalchemy
 
 |pypi-package| |build-status| |docs|
 
-Homepage: http://marshmallow-sqlalchemy.rtfd.org/
+Homepage: https://marshmallow-sqlalchemy.readthedocs.io/
 
-`SQLAlchemy <http://www.sqlalchemy.org/>`_ integration with the  `marshmallow <https://marshmallow.readthedocs.org/en/latest/>`_ (de)serialization library.
+`SQLAlchemy <http://www.sqlalchemy.org/>`_ integration with the  `marshmallow <https://marshmallow.readthedocs.io/en/latest/>`_ (de)serialization library.
 
 Declare your models
 ===================
@@ -85,13 +85,13 @@ Get it now
 Documentation
 =============
 
-Documentation is available at http://marshmallow-sqlalchemy.readthedocs.org/ .
+Documentation is available at https://marshmallow-sqlalchemy.readthedocs.io/ .
 
 Project Links
 =============
 
-- Docs: http://marshmallow-sqlalchemy.rtfd.org/
-- Changelog: http://marshmallow-sqlalchemy.readthedocs.org/en/latest/changelog.html
+- Docs: https://marshmallow-sqlalchemy.readthedocs.io/
+- Changelog: https://marshmallow-sqlalchemy.readthedocs.io/en/latest/changelog.html
 - PyPI: https://pypi.python.org/pypi/marshmallow-sqlalchemy
 - Issues: https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,8 +21,8 @@ primary_domain = 'py'
 default_role = 'py:obj'
 
 intersphinx_mapping = {
-    'python': ('http://python.readthedocs.org/en/latest/', None),
-    'marshmallow': ('http://marshmallow.readthedocs.org/en/latest/', None),
+    'python': ('https://python.readthedocs.io/en/latest/', None),
+    'marshmallow': ('https://marshmallow.readthedocs.io/en/latest/', None),
     'sqlalchemy': ('http://www.sqlalchemy.org/docs/', None),
 }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ marshmallow-sqlalchemy
 
 Release v\ |version| (:ref:`Changelog <changelog>`)
 
-`SQLAlchemy <http://www.sqlalchemy.org/>`_ integration with the  `marshmallow <https://marshmallow.readthedocs.org/en/latest/>`_ (de)serialization library.
+`SQLAlchemy <http://www.sqlalchemy.org/>`_ integration with the  `marshmallow <https://marshmallow.readthedocs.io/en/latest/>`_ (de)serialization library.
 
 Declare your models
 ===================


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
