### PR TITLE
Sqlalchemy 1.1 json type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - travis_retry pip install -U .
   - travis_retry pip install -r dev-requirements.txt
   # Install lowest supported sqlalchemy version
-  - travis_retry pip install sqlalchemy==1.1.0b3
+  - travis_retry pip install sqlalchemy==0.9.7
   - travis_retry pip install -U marshmallow"$MARSHMALLOW_VERSION"
 before_script:
   - flake8 .

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - travis_retry pip install -U .
   - travis_retry pip install -r dev-requirements.txt
   # Install lowest supported sqlalchemy version
-  - travis_retry pip install sqlalchemy==0.9.7
+  - travis_retry pip install sqlalchemy==1.1.0b3
   - travis_retry pip install -U marshmallow"$MARSHMALLOW_VERSION"
 before_script:
   - flake8 .

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,3 +16,4 @@ Contributors
 - Douglas Russell `@dpwrussell <https://github.com/dpwrussell>`_
 - Rudá Porto Filgueiras `@rudaporto <https://github.com/rudaporto>`_
 - Sean Harrington `@seanharr11 <https://github.com/seanharr11>`_
+- Eric Wittle `@ewittle <https://github.com/ewittle>`_

--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -66,7 +66,7 @@ class ModelConverter(object):
 
         mssql.BIT: fields.Integer,
     }
-    if sa.JSON:
+    if hasattr(sa,'JSON'):
         SQLA_TYPE_MAPPING[sa.JSON] = fields.Raw
 
     DIRECTION_MAPPING = {

--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -65,6 +65,7 @@ class ModelConverter(object):
         mysql.ENUM: fields.Field,
 
         mssql.BIT: fields.Integer,
+        sa.JSON: fields.Raw,
     }
 
     DIRECTION_MAPPING = {

--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -66,7 +66,7 @@ class ModelConverter(object):
 
         mssql.BIT: fields.Integer,
     }
-    if hasattr(sa,'JSON'):
+    if hasattr(sa, 'JSON'):
         SQLA_TYPE_MAPPING[sa.JSON] = fields.Raw
 
     DIRECTION_MAPPING = {

--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -65,8 +65,9 @@ class ModelConverter(object):
         mysql.ENUM: fields.Field,
 
         mssql.BIT: fields.Integer,
-        sa.JSON: fields.Raw,
     }
+    if sa.JSON:
+        SQLA_TYPE_MAPPING[sa.JSON] = fields.Raw
 
     DIRECTION_MAPPING = {
         'MANYTOONE': False,


### PR DESCRIPTION
Well, the commit history is ugly, but the end result seems to accomplish what I'm after. The goal is to support the sqlalchemy 1.1 data type of JSON, without breaking the past. This does pass the Travis build (which caught most of the issues that drove the ugly commit history). 
