### PR TITLE
Ensure validator choices are a list.

### DIFF
--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -308,7 +308,7 @@ class TestModelFieldConversion:
         fields_ = fields_for_model(models.Course)
         validator = contains_validator(fields_['level'], validate.OneOf)
         assert validator
-        assert validator.choices == ('Primary', 'Secondary')
+        assert list(validator.choices) == ['Primary', 'Secondary']
 
     def test_many_to_many_relationship(self, models):
         student_fields = fields_for_model(models.Student)


### PR DESCRIPTION
SQLAlchemy switched enum choices from tuples to lists in release 1.1:
see https://github.com/zzzeek/sqlalchemy/blob/rel_1_1_0/lib/sqlalchemy/sql/sqltypes.py#L1268.

[Resolves #86]
