### PR TITLE
Make Nested deserialize throw ValidationError instead ValueError

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,3 +20,4 @@ Contributors
 - Alex Rothberg `@cancan101 <https://github.com/cancan101>`_
 - Vlad Frolov `@frol <https://github.com/frol>`_
 - Kelvin Hammond `@kelvinhammond <https://github.com/kelvinhammond>`_
+- Yuri Heupa `@YuriHeupa <https://github.com/YuriHeupa>`_

--- a/marshmallow_sqlalchemy/fields.py
+++ b/marshmallow_sqlalchemy/fields.py
@@ -34,6 +34,11 @@ class Related(fields.Field):
         the primary key(s) of the related model will be used.
     """
 
+    default_error_messages = {
+        'invalid': 'Could not deserialize related value {value!r}; '
+                   'expected a dictionary with keys {keys!r}'
+    }
+
     def __init__(self, column=None, **kwargs):
         super(Related, self).__init__(**kwargs)
         self.columns = ensure_list(column or [])
@@ -71,13 +76,7 @@ class Related(fields.Field):
     def _deserialize(self, value, *args, **kwargs):
         if not isinstance(value, dict):
             if len(self.related_keys) != 1:
-                raise ValueError(
-                    'Could not deserialize related value {0!r}; expected a dictionary '
-                    'with keys {1!r}'.format(
-                        value,
-                        [prop.key for prop in self.related_keys]
-                    )
-                )
+                self.fail('invalid', value=value, keys=[prop.key for prop in self.related_keys])
             value = {self.related_keys[0].key: value}
         try:
             return self.session.query(

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -714,8 +714,9 @@ class TestModelSchema:
         schema = schemas.LectureSchema()
         dump_data = schema.dump(lecture).data
         dump_data['seminar'] = 'scalar'
-        with pytest.raises(ValueError):
-            schema.load(dump_data)
+        result = schema.load(dump_data)
+        assert result.errors
+        assert 'seminar' in result.errors
 
     def test_model_schema_loading_passing_session_to_load(self, models, schemas, student, session):
         class StudentSchemaNoSession(ModelSchema):


### PR DESCRIPTION
Raising a ValueError doesn't make sense within deserialize context. Bad input data should be caught as a validation error, so it was changed to the proper error.

This also fixes a minor typo in the error message.