### PR TITLE
Allow getting session from the context.

### DIFF
--- a/marshmallow_sqlalchemy/schema.py
+++ b/marshmallow_sqlalchemy/schema.py
@@ -137,11 +137,14 @@ class ModelSchema(with_metaclass(ModelSchemaMeta, ma.Schema)):
     """
     OPTIONS_CLASS = ModelSchemaOpts
 
+    @property
+    def session(self):
+        return self._session or self.opts.sqla_session
+
     def __init__(self, *args, **kwargs):
-        session = kwargs.pop('session', None)
+        self._session = kwargs.pop('session', None)
         self.instance = kwargs.pop('instance', None)
         super(ModelSchema, self).__init__(*args, **kwargs)
-        self.session = session or self.opts.sqla_session
 
     def get_instance(self, data):
         """Retrieve an existing record by primary key(s)."""
@@ -179,7 +182,7 @@ class ModelSchema(with_metaclass(ModelSchemaMeta, ma.Schema)):
         :param session: Optional SQLAlchemy session.
         :param instance: Optional existing instance to modify.
         """
-        self.session = session or self.session
+        self._session = session or self._session
         if not self.session:
             raise ValueError('Deserialization requires a session')
         self.instance = instance or self.instance
@@ -189,7 +192,7 @@ class ModelSchema(with_metaclass(ModelSchemaMeta, ma.Schema)):
             self.instance = None
 
     def validate(self, data, session=None, *args, **kwargs):
-        self.session = session or self.session
+        self._session = session or self._session
         if not self.session:
             raise ValueError('Validation requires a session')
         return super(ModelSchema, self).validate(data, *args, **kwargs)

--- a/marshmallow_sqlalchemy/schema.py
+++ b/marshmallow_sqlalchemy/schema.py
@@ -141,6 +141,10 @@ class ModelSchema(with_metaclass(ModelSchemaMeta, ma.Schema)):
     def session(self):
         return self._session or self.opts.sqla_session
 
+    @session.setter
+    def session(self, session):
+        self._session = session
+
     def __init__(self, *args, **kwargs):
         self._session = kwargs.pop('session', None)
         self.instance = kwargs.pop('instance', None)

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -987,3 +987,36 @@ class TestDeserializeObjectThatDNE:
         # Assume that if 1 lecture has a field with the correct String value, all strings
         # were successfully deserialized in nested objects
         assert(deserialized_seminar_object.lectures[0].topic == "Intro to Ter'Angreal")
+
+class TestMarshmallowContext:
+    def test_getting_session_from_marshmallow_context(self, session, models):
+        class SchoolSchema(ModelSchema):
+
+            @property
+            def session(self):
+                return self.context.get('session', None) or self._session or self.opts.sqla_session
+
+            class Meta:
+                model = models.School
+                fields = ('name',)
+
+        class SchoolWrapperSchema(Schema):
+            school = fields.Nested(SchoolSchema)
+            schools = fields.Nested(SchoolSchema, many=True)
+
+        schema = SchoolWrapperSchema(context=dict(session=session))
+        data = {
+            'school': {'name': 'one school'},
+            'schools': [{'name': 'another school'}, {'name': 'yet, another school'}],
+        }
+        result = schema.load(data)
+        session.add(result.data['school'])
+        session.add_all(result.data['schools'])
+        session.flush()
+        assert isinstance(result.data['school'], models.School)
+        assert isinstance(result.data['school'].id, int)
+        for school in result.data['schools']:
+            assert isinstance(school, models.School)
+            assert isinstance(school.id, int)
+        dump_result = schema.dump(result.data)
+        assert dump_result.data == data

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -1009,14 +1009,14 @@ class TestMarshmallowContext:
             'school': {'name': 'one school'},
             'schools': [{'name': 'another school'}, {'name': 'yet, another school'}],
         }
-        result = schema.load(data)
-        session.add(result.data['school'])
-        session.add_all(result.data['schools'])
+        result = unpack(schema.load(data))
+        session.add(result['school'])
+        session.add_all(result['schools'])
         session.flush()
-        assert isinstance(result.data['school'], models.School)
-        assert isinstance(result.data['school'].id, int)
-        for school in result.data['schools']:
+        assert isinstance(result['school'], models.School)
+        assert isinstance(result['school'].id, int)
+        for school in result['schools']:
             assert isinstance(school, models.School)
             assert isinstance(school.id, int)
-        dump_result = schema.dump(result.data)
-        assert dump_result.data == data
+        dump_result = unpack(schema.dump(result))
+        assert dump_result == data


### PR DESCRIPTION
Hey,

Sometimes you are not able to provide the session to the Meta class and you want to mix marshmallow schema with marshmallow-sqlalchemy. The only place where you can put the session is the context (but you do it is up to you). With this PR you can override the session property to include session from context (example included in tests).

Cheers