### PR TITLE
Preserve Excluded Keys

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -25,3 +25,4 @@ Contributors
 - Ilya Chistyakov `@ilya-chistyakov <https://github.com/ilya-chistyakov>`_
 - Victor Gavro `@vgavro <https://github.com/vgavro>`_
 - Maciej Barański `@gtxm <https://github.com/gtxm>`_
+- Jared Deckard `@deckar01 <https://github.com/deckar01>`_

--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -92,6 +92,8 @@ class ModelConverter(object):
         base_fields = base_fields or {}
         for prop in model.__mapper__.iterate_properties:
             if _should_exclude_field(prop, fields=fields, exclude=exclude):
+                # Allow marshmallow to validate and exclude the field key.
+                result[prop.key] = None
                 continue
             if hasattr(prop, 'columns'):
                 if not include_fk:

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -303,7 +303,7 @@ class TestModelFieldConversion:
         fields_ = fields_for_model(models.Student, exclude=('dob', ))
         assert type(fields_['id']) is fields.Int
         assert type(fields_['full_name']) is fields.Str
-        assert 'dob' not in fields_
+        assert fields_['dob'] is None
 
     def test_fields_for_model_handles_custom_types(self, models):
         fields_ = fields_for_model(models.Course, include_fk=True)


### PR DESCRIPTION
Fix #131

Instead of omitting the keys from the field dictionary, they keys are assigned a value of `None`. This avoids calling `property2field()` for excluded fields and lets marshmallow validate the `exclude` option for mistakes.

This is backwards compatible with marshmallow 2.x, because marshmallow discards excluded fields before attempting to use the field values.

This feature was already covered by a test and it was failing for marshmallow 3, so no additional tests are needed. One unit test that covered the `fields_for_model` utility was updated to expect the implementation change.