### PR TITLE
Allow to override field kwargs at model layer

### DIFF
--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -142,6 +142,21 @@ You can use the `field_for <marshmallow_sqlalchemy.field_for>` function to gener
             model = Author
             sqla_session = Session
 
+You can customize the keyword arguments passed to a column property's corresponding marshmallow field by passing the ``info`` argument to the `Column`.
+
+.. code-block:: python
+
+    class Book(Model):
+        # ...
+
+        abstract = Column(
+            Text(),
+            info=dict(
+                marshmallow=dict(required=True),
+            ),
+        )
+
+
 Automatically Generating Schemas For SQLAlchemy Models
 ======================================================
 


### PR DESCRIPTION
e.g.:

```python
    class Book(Model):
        # ...

        abstract = Column(
            Text(),
            info=dict(
                schema=dict(required=True),
            ),
        )
```