### PR TITLE
Feature/allow transient model loading option

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,3 +28,4 @@ Contributors
 - Jared Deckard `@deckar01 <https://github.com/deckar01>`_
 - AbdealiJK `@AbdealiJK <https://github.com/AbdealiJK>`_
 - jean-philippe serafin `@jeanphix <https://github.com/jeanphix>`_
+- Jack Smith `@jacksmith15 <https://github.com/jacksmith15>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.16.0 (unreleased)
++++++++++++++++++++
+
+Features:
+
+* Add support for deserializing transient objects (:issue:`62`).
+  Thanks :user:`jacksmith15` for the PR.
+
 0.15.0 (2018-11-05)
 +++++++++++++++++++
 

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -308,4 +308,6 @@ You may also explicitly specify an override by passing the same argument to `loa
     print(AuthorSchema().load(dump_data, transient=True).data)
     # <Author(name='John Steinbeck')>
 
+Note that this transience will propagate to across relationships (i.e. auto-generated schemas for nested items will also be transient).
+
 See `State Management <https://docs.sqlalchemy.org/en/latest/orm/session_state_management.html>`_ to understand session state management.

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -273,3 +273,36 @@ An example of then using this:
     book = Book.query.options(joinedload('author')).get(1)
     print(BookSchema().dump(book).data['author'])
     # {'id': 1, 'name': 'Chuck Paluhniuk'}
+
+Transient Object Creation
+=========================
+
+Sometimes it might be desirable to deserialize instances that are transient (not attached to a session). In these cases you can specify an option in the `Meta <marshmallow_sqlalchemy.ModelSchemaOpts>` class of a `ModelSchema <marshmallow_sqlalchemy.ModelSchema>`.
+
+.. code-block:: python
+
+    from marshmallow_sqlalchemy import ModelSchema
+
+    class AuthorSchema(ModelSchema):
+        class Meta:
+            model = Author
+            transient = True
+
+    dump_data = {'id': 1, 'name': 'John Steinbeck'}
+    print(AuthorSchema().load(dump_data).data)
+    # <Author(name='John Steinbeck')>
+
+You may also explicitly specify an override by passing the same argument to `load <marshmallow_sqlalchemy.ModelSchema.load>`.
+
+.. code-block:: python
+
+    from marshmallow_sqlalchemy import ModelSchema
+
+    class AuthorSchema(ModelSchema):
+        class Meta:
+            model = Author
+            sqla_session = Session
+
+    dump_data = {'id': 1, 'name': 'John Steinbeck'}
+    print(AuthorSchema().load(dump_data, transient=True).data)
+    # <Author(name='John Steinbeck')>

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -277,7 +277,8 @@ An example of then using this:
 Transient Object Creation
 =========================
 
-Sometimes it might be desirable to deserialize instances that are transient (not attached to a session). In these cases you can specify an option in the `Meta <marshmallow_sqlalchemy.ModelSchemaOpts>` class of a `ModelSchema <marshmallow_sqlalchemy.ModelSchema>`.
+Sometimes it might be desirable to deserialize instances that are transient (not attached to a session). In these cases you can specify the `transient` option in the `Meta <marshmallow_sqlalchemy.ModelSchemaOpts>` class of a `ModelSchema <marshmallow_sqlalchemy.ModelSchema>`.
+
 
 .. code-block:: python
 
@@ -301,8 +302,10 @@ You may also explicitly specify an override by passing the same argument to `loa
     class AuthorSchema(ModelSchema):
         class Meta:
             model = Author
-            sqla_session = Session
+            sqla_session = session
 
     dump_data = {'id': 1, 'name': 'John Steinbeck'}
     print(AuthorSchema().load(dump_data, transient=True).data)
     # <Author(name='John Steinbeck')>
+
+See `State Management <https://docs.sqlalchemy.org/en/latest/orm/session_state_management.html>`_ to understand session state management.

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -308,6 +308,9 @@ You may also explicitly specify an override by passing the same argument to `loa
     print(AuthorSchema().load(dump_data, transient=True).data)
     # <Author(name='John Steinbeck')>
 
-Note that this transience will propagate to across relationships (i.e. auto-generated schemas for nested items will also be transient).
+Note that transience propagates to relationships (i.e. auto-generated schemas for nested items will also be transient).
 
-See `State Management <https://docs.sqlalchemy.org/en/latest/orm/session_state_management.html>`_ to understand session state management.
+
+.. seealso::
+
+    See `State Management <https://docs.sqlalchemy.org/en/latest/orm/session_state_management.html>`_ to understand session state management.

--- a/marshmallow_sqlalchemy/fields.py
+++ b/marshmallow_sqlalchemy/fields.py
@@ -104,8 +104,6 @@ class Related(fields.Field):
             value = {self.related_keys[0].key: value}
         if self.transient:
             return self.related_model(**value)
-        if not self.session:
-            raise ValueError('Deserialization requires a session!')
         try:
             result = self._get_existing_instance(
                 self.session.query(self.related_model),

--- a/marshmallow_sqlalchemy/fields.py
+++ b/marshmallow_sqlalchemy/fields.py
@@ -79,6 +79,11 @@ class Related(fields.Field):
         schema = get_schema_for_field(self)
         return schema.session
 
+    @property
+    def transient(self):
+        schema = get_schema_for_field(self)
+        return schema.transient
+
     def _serialize(self, value, attr, obj):
         ret = {
             prop.key: getattr(value, prop.key, None)
@@ -87,26 +92,48 @@ class Related(fields.Field):
         return ret if len(ret) > 1 else list(ret.values())[0]
 
     def _deserialize(self, value, *args, **kwargs):
+        """Deserialize a serialized value to a model instance.
+
+        If the parent schema is transient, create a new (transient) instance.
+        Otherwise, attempt to find an existing instance in the database.
+        :param value: The value to deserialize.
+        """
         if not isinstance(value, dict):
             if len(self.related_keys) != 1:
                 self.fail('invalid', value=value, keys=[prop.key for prop in self.related_keys])
             value = {self.related_keys[0].key: value}
-        query = self.session.query(self.related_model)
+        if self.transient:
+            return self.related_model(**value)
+        if not self.session:
+            raise ValueError('Deserialization requires a session!')
         try:
-            if self.columns:
-                result = query.filter_by(**{
-                    prop.key: value.get(prop.key)
-                    for prop in self.related_keys
-                }).one()
-            else:
-                # Use a faster path if the related key is the primary key.
-                result = query.get([
-                    value.get(prop.key) for prop in self.related_keys
-                ])
-                if result is None:
-                    raise NoResultFound
+            result = self._get_existing_instance(
+                self.session.query(self.related_model),
+                value,
+            )
         except NoResultFound:
             # The related-object DNE in the DB, but we still want to deserialize it
             # ...perhaps we want to add it to the DB later
             return self.related_model(**value)
+        return result
+
+    def _get_existing_instance(self, query, value):
+        """Retrieve the related object from an existing instance in the DB.
+
+        :param query: A SQLAlchemy `Query <sqlalchemy.orm.query.Query>` object.
+        :param value: The serialized value to mapto an existing instance.
+        :raises NoResultFound: if there is no matching record.
+        """
+        if self.columns:
+            result = query.filter_by(**{
+                prop.key: value.get(prop.key)
+                for prop in self.related_keys
+            }).one()
+        else:
+            # Use a faster path if the related key is the primary key.
+            result = query.get([
+                value.get(prop.key) for prop in self.related_keys
+            ])
+            if result is None:
+                raise NoResultFound
         return result

--- a/marshmallow_sqlalchemy/schema.py
+++ b/marshmallow_sqlalchemy/schema.py
@@ -32,6 +32,8 @@ class ModelSchemaOpts(ma.SchemaOpts):
     - ``model_converter``: `ModelConverter` class to use for converting the SQLAlchemy model to
         marshmallow fields.
     - ``include_fk``: Whether to include foreign fields; defaults to `False`.
+    - ``transient``: Whether load model instances in a transient state (effectively ignoring
+        the session).
     """
 
     def __init__(self, meta, *args, **kwargs):

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -1095,6 +1095,25 @@ class TestModelSchema:
         state = sa.inspect(load_data)
         assert state.transient
 
+    def test_transient_load_with_unknown_include(self, models, session, school):
+        if MARSHMALLOW_VERSION_INFO[0] < 3:
+            return
+
+        class SchoolSchemaTransient(ModelSchema):
+            class Meta:
+                model = models.School
+                sqla_session = session
+                unknown = marshmallow.INCLUDE
+
+        sch = SchoolSchemaTransient()
+        dump_data = unpack(sch.dump(school))
+        dump_data['foo'] = 'bar'
+        load_data = unpack(sch.load(dump_data, transient=True))
+
+        assert isinstance(load_data, models.School)
+        state = sa.inspect(load_data)
+        assert state.transient
+
     def test_transient_schema_with_relationship(self, models, student_with_teachers, session):
         class StudentSchemaTransient(ModelSchema):
             class Meta:

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -1047,6 +1047,19 @@ class TestModelSchema:
         state = sa.inspect(load_data)
         assert state.transient
 
+    def test_transient_schema_with_relationship(self, models, student):
+        class StudentSchemaTransient(ModelSchema):
+            class Meta:
+                model = models.Student
+                transient = True
+
+        sch = StudentSchemaTransient()
+        dump_data = unpack(sch.dump(student))
+        load_data = unpack(sch.load(dump_data))
+        assert isinstance(load_data, models.Student)
+        state = sa.inspect(load_data)
+        assert state.transient
+
 
 class TestNullForeignKey:
     @pytest.fixture()

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -1021,6 +1021,33 @@ class TestModelSchema:
             err = excinfo.value
             assert err.messages == {'students': ['Unknown field.']}
 
+    def test_transient_schema(self, models, school):
+        class SchoolSchemaTransient(ModelSchema):
+            class Meta:
+                model = models.School
+                transient = True
+
+        sch = SchoolSchemaTransient()
+        dump_data = unpack(sch.dump(school))
+        load_data = unpack(sch.load(dump_data))
+        assert isinstance(load_data, models.School)
+        state = sa.inspect(load_data)
+        assert state.transient
+
+    def test_transient_load(self, models, session, school):
+        class SchoolSchemaTransient(ModelSchema):
+            class Meta:
+                model = models.School
+                sqla_session = session
+
+        sch = SchoolSchemaTransient()
+        dump_data = unpack(sch.dump(school))
+        load_data = unpack(sch.load(dump_data, transient=True))
+        assert isinstance(load_data, models.School)
+        state = sa.inspect(load_data)
+        assert state.transient
+
+
 class TestNullForeignKey:
     @pytest.fixture()
     def school(self, models, session):

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -1059,6 +1059,10 @@ class TestModelSchema:
         assert isinstance(load_data, models.Student)
         state = sa.inspect(load_data)
         assert state.transient
+        school = load_data.current_school
+        assert isinstance(school, models.School)
+        school_state = sa.inspect(school)
+        assert school_state.transient
 
 
 class TestNullForeignKey:

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -1095,10 +1095,11 @@ class TestModelSchema:
         state = sa.inspect(load_data)
         assert state.transient
 
+    @pytest.mark.skipif(
+        MARSHMALLOW_VERSION_INFO[0] < 3,
+        reason='`unknown` was added in marshmallow 3',
+    )
     def test_transient_load_with_unknown_include(self, models, session, school):
-        if MARSHMALLOW_VERSION_INFO[0] < 3:
-            return
-
         class SchoolSchemaTransient(ModelSchema):
             class Meta:
                 model = models.School


### PR DESCRIPTION
# What's Changed
- Add a `transient` option which allows construction of SQLAlchemy model instances which are not attached to a session.
- Force association proxies to be parsed _after_ regular keyword arguments, to prevent errors on instantiation.

# Background
- Allows model instances to be constructed without an open session, which may be useful in situations with unusual session management, or when some logic is performed on the complete model instance which may drive whether it becomes added to the session.

- [x] Unit tests updated
- [x] Unit tests passing
- [x] Linting passing
- [x] Changes documented in docstrings
- [x] Recipe added to documentation