### PR TITLE
Field overrides for tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,77 @@
+### macOS template
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+### Linux template
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+
+### Windows template
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+
+### JetBrains
+.idea
+
 *.py[cod]
 
 # C extensions

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,3 +28,4 @@ Contributors
 - Jared Deckard `@deckar01 <https://github.com/deckar01>`_
 - AbdealiJK `@AbdealiJK <https://github.com/AbdealiJK>`_
 - jean-philippe serafin `@jeanphix <https://github.com/jeanphix>`_
+- Nikita Koshelev `@nkoshell <http://github.com/nkohsell>`_

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -10,6 +10,9 @@ API Reference
     .. autodata:: marshmallow_sqlalchemy.fields_for_model
         :annotation: =func(...)
 
+    .. autodata:: marshmallow_sqlalchemy.fields_for_table
+        :annotation: =func(...)
+
     .. autodata:: marshmallow_sqlalchemy.property2field
         :annotation: =func(...)
 

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -156,6 +156,25 @@ You can customize the keyword arguments passed to a column property's correspond
             ),
         )
 
+or
+
+.. code-block:: python
+
+    import sqlalchemy as sa
+
+    books = sa.Table('books',
+        # ...
+
+        sa.Column(
+            'abstract',
+            sa.Text(),
+            info=dict(
+                marshmallow=dict(required=True),
+            ),
+        )
+    )
+
+
 
 Automatically Generating Schemas For SQLAlchemy Models
 ======================================================

--- a/marshmallow_sqlalchemy/__init__.py
+++ b/marshmallow_sqlalchemy/__init__.py
@@ -1,13 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from .schema import (
-    TableSchemaOpts,
-    ModelSchemaOpts,
-    TableSchema,
-    ModelSchema,
-)
-
 from .convert import (
     ModelConverter,
     fields_for_model,
@@ -15,6 +8,14 @@ from .convert import (
     column2field,
     field_for,
 )
+
+from .schema import (
+    TableSchemaOpts,
+    ModelSchemaOpts,
+    TableSchema,
+    ModelSchema,
+)
+
 from .exceptions import ModelConversionError
 
 __version__ = '0.15.0'

--- a/marshmallow_sqlalchemy/__init__.py
+++ b/marshmallow_sqlalchemy/__init__.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from .convert import (
     ModelConverter,
     fields_for_model,
+    fields_for_table,
     property2field,
     column2field,
     field_for,
@@ -28,6 +29,7 @@ __all__ = [
     'ModelSchemaOpts',
     'ModelConverter',
     'fields_for_model',
+    'fields_for_table',
     'property2field',
     'column2field',
     'ModelConversionError',

--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -146,6 +146,7 @@ class ModelConverter(object):
             return field_class
         field_kwargs = self.get_base_kwargs()
         self._add_column_kwargs(field_kwargs, column)
+        self._apply_field_kwargs_overrides(field_kwargs, column)
         field_kwargs.update(kwargs)
         return field_class(**field_kwargs)
 
@@ -209,7 +210,11 @@ class ModelConverter(object):
             self._add_relationship_kwargs(kwargs, prop)
         if getattr(prop, 'doc', None):  # Useful for documentation generation
             kwargs['description'] = prop.doc
-        info = getattr(prop, 'info', dict())
+        self._apply_field_kwargs_overrides(kwargs, prop)
+        return kwargs
+
+    def _apply_field_kwargs_overrides(self, kwargs, prop_or_column):
+        info = getattr(prop_or_column, 'info', dict())
         overrides = info.get('marshmallow')
         if overrides is not None:
             validate = overrides.pop('validate', [])
@@ -218,7 +223,6 @@ class ModelConverter(object):
                 validate,
             )  # Ensure we do not override the generated validators.
             kwargs.update(overrides)  # Override other kwargs.
-        return kwargs
 
     def _add_column_kwargs(self, kwargs, column):
         """Add keyword arguments to kwargs (in-place) based on the passed in

--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -1,21 +1,23 @@
 # -*- coding: utf-8 -*-
-import inspect
 import functools
-
+import inspect
 import uuid
+
 import marshmallow as ma
-from marshmallow import validate, fields
-from sqlalchemy.dialects import postgresql, mysql, mssql
 import sqlalchemy as sa
+from marshmallow import fields, validate
+from sqlalchemy.dialects import mssql, mysql, postgresql
 
 from .exceptions import ModelConversionError
 from .fields import Related, RelatedList
+
 
 def _is_field(value):
     return (
         isinstance(value, type) and
         issubclass(value, fields.Field)
     )
+
 
 def _has_default(column):
     return (
@@ -24,17 +26,20 @@ def _has_default(column):
         _is_auto_increment(column)
     )
 
+
 def _is_auto_increment(column):
     return (
         column.table is not None and
         column is column.table._autoincrement_column
     )
 
+
 def _postgres_array_factory(converter, data_type):
     return functools.partial(
         fields.List,
         converter._get_field_class_for_data_type(data_type.item_type),
     )
+
 
 class ModelConverter(object):
     """Class that converts a SQLAlchemy model into a dictionary of corresponding

--- a/marshmallow_sqlalchemy/convert.py
+++ b/marshmallow_sqlalchemy/convert.py
@@ -284,6 +284,15 @@ given model.
 :return: dict of field_name: Field instance pairs
 """
 
+fields_for_table = default_converter.fields_for_table
+"""Generate a dict of field_name: `marshmallow.fields.Field` pairs for the
+given table.
+
+:param table: The SQLAlchemy table
+:param bool include_fk: Whether to include foreign key fields in the output.
+:return: dict of field_name: Field instance pairs
+"""
+
 property2field = default_converter.property2field
 """Convert a SQLAlchemy `Property` to a field instance or class.
 

--- a/marshmallow_sqlalchemy/exceptions.py
+++ b/marshmallow_sqlalchemy/exceptions.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
+
 class MarshmallowSQLAlchemyError(Exception):
     """Base exception class from which all exceptions related to
     marshmallow-sqlalchemy inherit.
     """
     pass
+
 
 class ModelConversionError(MarshmallowSQLAlchemyError):
     """Raised when an error occurs in converting a SQLAlchemy construct

--- a/marshmallow_sqlalchemy/fields.py
+++ b/marshmallow_sqlalchemy/fields.py
@@ -2,9 +2,9 @@
 
 from marshmallow import fields
 from marshmallow.utils import is_iterable_but_not_string
-
-from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.ext.associationproxy import AssociationProxy
+from sqlalchemy.orm.exc import NoResultFound
+
 
 def get_primary_keys(model):
     """Get primary key properties for a SQLAlchemy model.
@@ -17,14 +17,17 @@ def get_primary_keys(model):
         for column in mapper.primary_key
     ]
 
+
 def get_schema_for_field(field):
     if hasattr(field, 'root'):  # marshmallow>=2.1
         return field.root
     else:
         return field.parent
 
+
 def ensure_list(value):
     return value if is_iterable_but_not_string(value) else [value]
+
 
 class RelatedList(fields.List):
 
@@ -34,6 +37,7 @@ class RelatedList(fields.List):
         # Instead call the `get_value` from the parent of `fields.List`
         # so the special handling is avoided.
         return super(fields.List, self).get_value(obj, attr, accessor=accessor)
+
 
 class Related(fields.Field):
     """Related data represented by a SQLAlchemy `relationship`. Must be attached

--- a/marshmallow_sqlalchemy/schema.py
+++ b/marshmallow_sqlalchemy/schema.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import marshmallow as ma
-from marshmallow.compat import with_metaclass, iteritems
+from marshmallow.compat import iteritems, with_metaclass
 
 from .convert import ModelConverter
 from .fields import get_primary_keys
@@ -22,6 +22,7 @@ class TableSchemaOpts(ma.SchemaOpts):
         self.model_converter = getattr(meta, 'model_converter', ModelConverter)
         self.include_fk = getattr(meta, 'include_fk', False)
 
+
 class ModelSchemaOpts(ma.SchemaOpts):
     """Options class for `ModelSchema`.
     Adds the following options:
@@ -40,6 +41,7 @@ class ModelSchemaOpts(ma.SchemaOpts):
         self.sqla_session = getattr(meta, 'sqla_session', None)
         self.model_converter = getattr(meta, 'model_converter', ModelConverter)
         self.include_fk = getattr(meta, 'include_fk', False)
+
 
 class SchemaMeta(ma.schema.SchemaMeta):
     """Metaclass for `ModelSchema`."""
@@ -65,6 +67,7 @@ class SchemaMeta(ma.schema.SchemaMeta):
     def get_fields(mcs, converter, base_fields, opts):
         pass
 
+
 class TableSchemaMeta(SchemaMeta):
 
     @classmethod
@@ -80,6 +83,7 @@ class TableSchemaMeta(SchemaMeta):
             )
         return dict_cls()
 
+
 class ModelSchemaMeta(SchemaMeta):
 
     @classmethod
@@ -94,6 +98,7 @@ class ModelSchemaMeta(SchemaMeta):
                 dict_cls=dict_cls,
             )
         return dict_cls()
+
 
 class TableSchema(with_metaclass(TableSchemaMeta, ma.Schema)):
     """Base class for SQLAlchemy model-based Schemas.
@@ -114,6 +119,7 @@ class TableSchema(with_metaclass(TableSchemaMeta, ma.Schema)):
         serialized = schema.dump(user).data
     """
     OPTIONS_CLASS = TableSchemaOpts
+
 
 class ModelSchema(with_metaclass(ModelSchemaMeta, ma.Schema)):
     """Base class for SQLAlchemy model-based Schemas.

--- a/tests/test_marshmallow_sqlalchemy.py
+++ b/tests/test_marshmallow_sqlalchemy.py
@@ -22,6 +22,7 @@ from marshmallow_sqlalchemy import (
     column2field,
     field_for,
     fields_for_model,
+    fields_for_table,
     property2field,
 )
 from marshmallow_sqlalchemy.fields import Related, RelatedList
@@ -615,6 +616,13 @@ class TestTableSchema:
         schema = SchoolSchema()
         data = unpack(schema.dump(school))
         assert data == {'name': 'Univ. of Whales', 'school_id': 1}
+
+    def test_info_overrides(self, models):
+        fields_ = fields_for_table(models.Course.__table__)
+        field = fields_['description']
+        validator = contains_validator(field, validate.Length)
+        assert validator.max == 1000
+        assert field.required
 
 
 class TestModelSchema:


### PR DESCRIPTION
## Changes 
- Code reformat

## Additions
- Few new template for `.gitignore`
- `fields_for_table` now available in as module level function
- Overrides functionality now available for tables too, e.g.:
    ```python
    import sqlalchemy as sa

    books = sa.Table('books',
        # ...

        sa.Column(
            'abstract',
            sa.Text(),
            info=dict(
                marshmallow=dict(required=True),
            ),
        )
    )
    ```