### PR TITLE
fix: remove trailing commas in parameter list

### DIFF
--- a/src/marshmallow_sqlalchemy/convert.py
+++ b/src/marshmallow_sqlalchemy/convert.py
@@ -76,7 +76,7 @@ class ModelConverter:
         fields=None,
         exclude=None,
         base_fields=None,
-        dict_cls=dict,
+        dict_cls=dict
     ):
         result = dict_cls()
         base_fields = base_fields or {}
@@ -107,7 +107,7 @@ class ModelConverter:
         fields=None,
         exclude=None,
         base_fields=None,
-        dict_cls=dict,
+        dict_cls=dict
     ):
         result = dict_cls()
         base_fields = base_fields or {}


### PR DESCRIPTION
Python 3.5.3 throws an exception when executing code that has a trailing comma in the parameter list as found on a couple of lines in `convert.py`. Remove those trailing commas.

For context, I encountered the error when running `airflow scheduler` using Python 3.5.3 (in a Google Compute instance):
```
Traceback (most recent call last):
  File "/usr/local/bin/airflow", line 22, in <module>
    from airflow.bin.cli import CLIFactory
  File "/usr/local/lib/python3.5/dist-packages/airflow/bin/cli.py", line 68, in <module>
    from airflow.www_rbac.app import cached_app as cached_app_rbac
  File "/usr/local/lib/python3.5/dist-packages/airflow/www_rbac/app.py", line 26, in <module>
    from flask_appbuilder import AppBuilder, SQLA
  File "/usr/local/lib/python3.5/dist-packages/flask_appbuilder/__init__.py", line 5, in <module>
    from .base import AppBuilder
  File "/usr/local/lib/python3.5/dist-packages/flask_appbuilder/base.py", line 5, in <module>
    from .api.manager import OpenApiManager
  File "/usr/local/lib/python3.5/dist-packages/flask_appbuilder/api/__init__.py", line 11, in <module>
    from marshmallow_sqlalchemy.fields import Related, RelatedList
  File "/usr/local/lib/python3.5/dist-packages/marshmallow_sqlalchemy/__init__.py", line 1, in <module>
    from .schema import TableSchemaOpts, ModelSchemaOpts, TableSchema, ModelSchema
  File "/usr/local/lib/python3.5/dist-packages/marshmallow_sqlalchemy/schema.py", line 3, in <module>
    from .convert import ModelConverter
  File "/usr/local/lib/python3.5/dist-packages/marshmallow_sqlalchemy/convert.py", line 80
    ):
```

After removing these two trailing commas I was able to run `airflow scheduler` successfully.