### PR TITLE
Don't advertise support for any Python3 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
-        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],


### PR DESCRIPTION
This package doesn't support Python 3.5 anymore.

setup.py has a `python_reqiures` of >= 3.6, but the classifiers are still checked when determining which Python versions are supported. Without this change, `python3.5 -m pip install marshmallow-sqlalchemy` still allows me to install the package without warnings.