### PR TITLE
Properly handle synonyms

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.22.2 (unreleased)
++++++++++++++++++++
+
+Bug fixes:
+
+* Avoid error when using ``SQLAlchemyModelSchema``, ``ModelSchema``, or ``fields_for_model``
+  with a model that has a ``SynonymProperty`` (:issue:`190`).
+* ``auto_field`` and ``field_for`` work with ``SynonymProperty``.
+
 0.22.1 (2020-02-09)
 +++++++++++++++++++
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, relationship, backref, column_property
+from sqlalchemy.orm import sessionmaker, relationship, backref, column_property, synonym
 from marshmallow import validate
 
 
@@ -118,6 +118,7 @@ def models(Base):
             sa.Integer, sa.ForeignKey(School.id), nullable=True
         )
         current_school = relationship(School, backref=backref("teachers"))
+        curr_school_id = synonym("current_school_id")
 
         substitute = relationship("SubstituteTeacher", uselist=False, backref="teacher")
 

--- a/tests/test_sqlalchemy_schema.py
+++ b/tests/test_sqlalchemy_schema.py
@@ -219,6 +219,31 @@ def test_passing_table_to_auto_field(models, teacher):
     }
 
 
+# https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/190
+def test_auto_schema_skips_synonyms(models):
+    class TeacherSchema(SQLAlchemyAutoSchema):
+        class Meta:
+            model = models.Teacher
+            include_fk = True
+
+    schema = TeacherSchema()
+    assert "current_school_id" in schema.fields
+    assert "curr_school_id" not in schema.fields
+
+
+def test_auto_field_works_with_synonym(models):
+    class TeacherSchema(SQLAlchemyAutoSchema):
+        class Meta:
+            model = models.Teacher
+            include_fk = True
+
+        curr_school_id = auto_field()
+
+    schema = TeacherSchema()
+    assert "current_school_id" in schema.fields
+    assert "curr_school_id" in schema.fields
+
+
 class TestAliasing:
     @pytest.fixture
     def aliased_schema(self, models):


### PR DESCRIPTION
close #190 

Synonyms are ignored when using fields_for_model.
auto_field and field_for now work with synonyms.