### PR TITLE
Fix example for SQLAlchemySchema

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -35,3 +35,4 @@ Contributors
 - Pierre Verkest `@petrus-v <https://github.com/petrus-v>`_
 - Erik Cederstrand `@ecederstrand <https://github.com/ecederstrand>`_
 - Daven Quinn `@davenquinn <https://github.com/davenquinn>`_
+- Peter Schutt `@5uper5hoot <https://github.com/5uper5hoot>`_

--- a/src/marshmallow_sqlalchemy/schema/sqlalchemy_schema.py
+++ b/src/marshmallow_sqlalchemy/schema/sqlalchemy_schema.py
@@ -148,11 +148,11 @@ class SQLAlchemySchema(
 
     Example: ::
 
-        from marshmallow_sqlalchemy import SQLAlchemyAutoSchema, auto_field
+        from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
 
-        from mymodels import User, session
+        from mymodels import User
 
-        class UserSchema(SQLAlchemy):
+        class UserSchema(SQLAlchemySchema):
             class Meta:
                 model = User
 
@@ -172,7 +172,7 @@ class SQLAlchemyAutoSchema(SQLAlchemySchema, metaclass=SQLAlchemyAutoSchemaMeta)
 
         from marshmallow_sqlalchemy import SQLAlchemyAutoSchema, auto_field
 
-        from mymodels import User, session
+        from mymodels import User
 
         class UserSchema(SQLAlchemyAutoSchema):
             class Meta:


### PR DESCRIPTION
Hi, I just noticed what appears to be an issue in the documented examples in the new `sqlalchemy_schema` modules. 

The example for `SQLAlchemySchema` imports `SQLAlchemyAutoSchema` and subclasses `SQLAlchemy` in the `UserSchema` class. Also, in that example and the `SQLAlchemyAutoSchema` example, I removed the `session` import as neither example makes use of it. I could add the `sqla_session` option to the `class Meta` in each example if you'd rather have it there?

Thanks for the helpful lib!