### PR TITLE
Related when column key different to attrib key.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -35,4 +35,4 @@ Contributors
 - Pierre Verkest `@petrus-v <https://github.com/petrus-v>`_
 - Erik Cederstrand `@ecederstrand <https://github.com/ecederstrand>`_
 - Daven Quinn `@davenquinn <https://github.com/davenquinn>`_
-- Peter Schutt `@5uper5hoot <https://github.com/5uper5hoot>`_
+- Peter Schutt `@peterschutt <https://github.com/peterschutt>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.23.0 (unreleased)
++++++++++++++++++++
+
+Bug fixes:
+
+* Fix data keys when using ``Related`` with a ``Column`` that is named differently
+  from its attribute (:issue:`299`). Thanks :user:`peterschutt` for the catch and patch.
+
 0.22.3 (2020-03-01)
 +++++++++++++++++++
 

--- a/src/marshmallow_sqlalchemy/fields.py
+++ b/src/marshmallow_sqlalchemy/fields.py
@@ -1,6 +1,7 @@
 from marshmallow import fields
 from marshmallow.utils import is_iterable_but_not_string
 
+from sqlalchemy import inspect
 from sqlalchemy.orm.exc import NoResultFound
 
 
@@ -58,9 +59,8 @@ class Related(fields.Field):
     @property
     def related_keys(self):
         if self.columns:
-            return [
-                self.related_model.__mapper__.columns[column] for column in self.columns
-            ]
+            insp = inspect(self.related_model)
+            return [insp.attrs[column] for column in self.columns]
         return get_primary_keys(self.related_model)
 
     @property

--- a/tests/test_sqlalchemy_schema.py
+++ b/tests/test_sqlalchemy_schema.py
@@ -374,9 +374,9 @@ def test_related_when_model_attribute_name_distinct_from_column_name(
 
         current_school = Related(["id", "name"])
 
-    dump_data = TeacherSchema().dump(teacher)
+    dump_data = unpack(TeacherSchema().dump(teacher))
     assert "school_id" not in dump_data["current_school"]
     assert dump_data["current_school"]["id"] == teacher.current_school.id
-    new_teacher = TeacherSchema().load(dump_data, transient=True)
+    new_teacher = unpack(TeacherSchema().load(dump_data, transient=True))
     assert new_teacher.current_school.id == teacher.current_school.id
-    assert TeacherSchema().load(dump_data) is teacher
+    assert unpack(TeacherSchema().load(dump_data)) is teacher


### PR DESCRIPTION
For #299 

`get_primary_keys()` returns `ColumnProperty` objects, so when columns
aren't specified to the `Related`  field, `Related.related_keys` returns
`ColumnProperty` objects and there there isn't an issue. However,
when columns are specified, `Related.related_keys` returns `Column`
objects, and their `key` attribute returns the column name, not the
instances attribute name. The issue only arises when a column is
explicitly named distinct from its ORM attribute name.

This change ensures that `Related.related_keys` always returns
`ColumnProperty` objects.