### PR TITLE
Set _creation_index attr on SQLAlchemyAutoField

### DIFF
--- a/src/marshmallow_sqlalchemy/schema/sqlalchemy_schema.py
+++ b/src/marshmallow_sqlalchemy/schema/sqlalchemy_schema.py
@@ -1,4 +1,4 @@
-from marshmallow.fields import FieldABC
+from marshmallow.fields import Field, FieldABC
 from marshmallow.schema import Schema, SchemaMeta, SchemaOpts
 import sqlalchemy as sa
 from sqlalchemy.ext.declarative import DeclarativeMeta
@@ -19,6 +19,8 @@ class SQLAlchemyAutoField(FieldABC):
         self.model = model
         self.table = table
         self.field_kwargs = field_kwargs
+        self._creation_index = Field._creation_index
+        Field._creation_index += 1
 
     def create_field(self, schema_opts, column_name, converter):
         model = self.model or schema_opts.model

--- a/src/marshmallow_sqlalchemy/schema/sqlalchemy_schema.py
+++ b/src/marshmallow_sqlalchemy/schema/sqlalchemy_schema.py
@@ -1,4 +1,4 @@
-from marshmallow.fields import Field, FieldABC
+from marshmallow.fields import Field
 from marshmallow.schema import Schema, SchemaMeta, SchemaOpts
 import sqlalchemy as sa
 from sqlalchemy.ext.declarative import DeclarativeMeta
@@ -10,8 +10,10 @@ from .load_instance_mixin import LoadInstanceMixin
 
 # This isn't really a field; it's a placeholder for the metaclass.
 # This should be considered private API.
-class SQLAlchemyAutoField(FieldABC):
+class SQLAlchemyAutoField(Field):
     def __init__(self, *, column_name=None, model=None, table=None, field_kwargs):
+        super().__init__()
+
         if model and table:
             raise ValueError("Cannot pass both `model` and `table` options.")
 
@@ -19,8 +21,6 @@ class SQLAlchemyAutoField(FieldABC):
         self.model = model
         self.table = table
         self.field_kwargs = field_kwargs
-        self._creation_index = Field._creation_index
-        Field._creation_index += 1
 
     def create_field(self, schema_opts, column_name, converter):
         model = self.model or schema_opts.model

--- a/tests/test_sqlalchemy_schema.py
+++ b/tests/test_sqlalchemy_schema.py
@@ -244,6 +244,16 @@ def test_auto_field_works_with_synonym(models):
     assert "curr_school_id" in schema.fields
 
 
+def test_auto_field_works_with_ordered_flag(models):
+    class TeacherSchema(SQLAlchemyAutoSchema):
+        class Meta:
+            model = models.Teacher
+            ordered = True
+            strict = True  # marshmallow 2 compat
+
+        full_name = auto_field()
+
+
 class TestAliasing:
     @pytest.fixture
     def aliased_schema(self, models):

--- a/tests/test_sqlalchemy_schema.py
+++ b/tests/test_sqlalchemy_schema.py
@@ -244,14 +244,19 @@ def test_auto_field_works_with_synonym(models):
     assert "curr_school_id" in schema.fields
 
 
+# Regresion test https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/306
 def test_auto_field_works_with_ordered_flag(models):
-    class TeacherSchema(SQLAlchemyAutoSchema):
+    class StudentSchema(SQLAlchemyAutoSchema):
         class Meta:
-            model = models.Teacher
+            model = models.Student
             ordered = True
             strict = True  # marshmallow 2 compat
 
         full_name = auto_field()
+
+    schema = StudentSchema()
+    # Declared fields precede auto-generated fields
+    assert tuple(schema.fields.keys()) == ("full_name", "id", "dob", "date_created")
 
 
 class TestAliasing:


### PR DESCRIPTION
close #306 

Sets the `_creation_index` attribute on `SQLAlchemyAutoField` so that [`marshmallow.schema._get_fields`](https://github.com/marshmallow-code/marshmallow/blob/425dd974aad3bef4582ae0b310f7184578a83956/src/marshmallow/schema.py#L57) doesn't fail when it tries to sort fields by that attribute:

```py        
fields.sort(key=lambda pair: pair[1]._creation_index)
```