### PR TITLE
Add support for auto_field + model association proxy fields that have local multiplicity

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -37,3 +37,4 @@ Contributors
 - Daven Quinn `@davenquinn <https://github.com/davenquinn>`_
 - Peter Schutt `@peterschutt <https://github.com/peterschutt>`_
 - Arash Fatahzade `@ArashFatahzade <https://github.com/arashfatahzade>`_
+- David Malakh `@Unix-Code <https://github.com/Unix-Code>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 ---------
 
+0.24.2 (unreleased)
++++++++++++++++++++
+
+* ``auto_field`` supports ``association_proxy`` fields with local multiplicity
+  (``uselist=True``) (:issue:`364`). Thanks :user:`Unix-Code`
+  for the catch and patch.
+
 0.24.1 (2020-11-20)
 +++++++++++++++++++
 
@@ -10,7 +17,7 @@ Changelog
 0.24.0 (2020-10-20)
 +++++++++++++++++++
 
-* *Backwards-incompatible*: Drop support for marshmallow 2.x, which is now EOL. 
+* *Backwards-incompatible*: Drop support for marshmallow 2.x, which is now EOL.
 * Test against Python 3.9.
 
 0.23.1 (2020-05-30)
@@ -37,7 +44,7 @@ Bug fixes:
 
 * Fix ``DeprecationWarning`` getting raised even when user code does not use
   ``TableSchema`` or ``ModelSchema`` (:issue:`289`).
-  Thanks :user:`5uper5hoot` for reporting. 
+  Thanks :user:`5uper5hoot` for reporting.
 
 0.22.2 (2020-02-09)
 +++++++++++++++++++

--- a/src/marshmallow_sqlalchemy/convert.py
+++ b/src/marshmallow_sqlalchemy/convert.py
@@ -170,11 +170,18 @@ class ModelConverter:
         target_model = model
         prop_name = property_name
         attr = getattr(model, property_name)
+        remote_with_local_multiplicity = False
         if hasattr(attr, "remote_attr"):
             target_model = attr.target_class
             prop_name = attr.value_attr
+            remote_with_local_multiplicity = attr.local_attr.prop.uselist
         prop = target_model.__mapper__.get_property(prop_name)
-        return self.property2field(prop, **kwargs)
+        converted_prop = self.property2field(prop, **kwargs)
+        return (
+            RelatedList(converted_prop, **kwargs)
+            if remote_with_local_multiplicity
+            else converted_prop
+        )
 
     def _get_field_name(self, prop_or_column):
         return prop_or_column.key

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,10 @@ def models(Base):
         id = sa.Column("school_id", sa.Integer, primary_key=True)
         name = sa.Column(sa.String(255), nullable=False)
 
+        student_ids = association_proxy(
+            "students", "id", creator=lambda sid: Student(id=sid)
+        )
+
         @property
         def url(self):
             return f"/schools/{self.id}"
@@ -97,7 +101,7 @@ def models(Base):
         possible_teachers = association_proxy("current_school", "teachers")
 
         courses = relationship(
-            "Course",
+            Course,
             secondary=student_course,
             backref=backref("students", lazy="dynamic"),
         )


### PR DESCRIPTION
### Changes
* There should be no breaking changes but now, additional functionality for certain cases of association proxy model fields which would otherwise result in an error (on load or dump)

Linked Issue: #364 