### PR TITLE
Override load_instance per schema instance

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -38,3 +38,4 @@ Contributors
 - Peter Schutt `@peterschutt <https://github.com/peterschutt>`_
 - Arash Fatahzade `@ArashFatahzade <https://github.com/arashfatahzade>`_
 - David Malakh `@Unix-Code <https://github.com/Unix-Code>`_
+- Martijn Pieters `@mjpieters <https://github.com/mjpieters>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+0.25.0 (unreleased)
++++++++++++++++++++
+
+* Add ``load_instance`` as a parameter to `SQLAlchemySchema` and `SQLAlchemyAutoSchema` (:pr:`380`).
+  Thanks :user:`mjpieters` for the PR.
+
 0.24.2 (2021-02-07)
 +++++++++++++++++++
 

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -330,3 +330,26 @@ Note that transience propagates to relationships (i.e. auto-generated schemas fo
 .. seealso::
 
     See `State Management <https://docs.sqlalchemy.org/en/latest/orm/session_state_management.html>`_ to understand session state management.
+
+Controlling instance loading
+============================
+
+You can override the schema ``load_instance`` flag by passing in a ``load_instance`` argument when creating the schema instance. Use this to switch between loading to a dictionary or to a model instance:
+
+.. code-block:: python
+
+    from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
+
+
+    class AuthorSchema(SQLAlchemyAutoSchema):
+        class Meta:
+            model = Author
+            sqla_session = Session
+            load_instance = True
+
+
+    dump_data = {"id": 1, "name": "John Steinbeck"}
+    print(AuthorSchema().load(dump_data))  # loading an instance
+    # <Author(name='John Steinbeck')>
+    print(AuthorSchema(load_instance=False).load(dump_data))  # loading a dict
+    # {"id": 1, "name": "John Steinbeck"}

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -331,7 +331,7 @@ Note that transience propagates to relationships (i.e. auto-generated schemas fo
 
     See `State Management <https://docs.sqlalchemy.org/en/latest/orm/session_state_management.html>`_ to understand session state management.
 
-Controlling instance loading
+Controlling Instance Loading
 ============================
 
 You can override the schema ``load_instance`` flag by passing in a ``load_instance`` argument when creating the schema instance. Use this to switch between loading to a dictionary or to a model instance:

--- a/src/marshmallow_sqlalchemy/schema/load_instance_mixin.py
+++ b/src/marshmallow_sqlalchemy/schema/load_instance_mixin.py
@@ -39,6 +39,7 @@ class LoadInstanceMixin:
             self._session = kwargs.pop("session", None)
             self.instance = kwargs.pop("instance", None)
             self._transient = kwargs.pop("transient", None)
+            self._load_instance = kwargs.pop("load_instance", self.opts.load_instance)
             super().__init__(*args, **kwargs)
 
         def get_instance(self, data):
@@ -64,7 +65,7 @@ class LoadInstanceMixin:
 
             :param data: Data to deserialize.
             """
-            if not self.opts.load_instance:
+            if not self._load_instance:
                 return data
             instance = self.instance or self.get_instance(data)
             if instance is not None:
@@ -86,7 +87,7 @@ class LoadInstanceMixin:
             """
             self._session = session or self._session
             self._transient = transient or self._transient
-            if self.opts.load_instance and not (self.transient or self.session):
+            if self._load_instance and not (self.transient or self.session):
                 raise ValueError("Deserialization requires a session")
             self.instance = instance or self.instance
             try:

--- a/src/marshmallow_sqlalchemy/schema/load_instance_mixin.py
+++ b/src/marshmallow_sqlalchemy/schema/load_instance_mixin.py
@@ -58,8 +58,9 @@ class LoadInstanceMixin:
         @ma.post_load
         def make_instance(self, data, **kwargs):
             """Deserialize data to an instance of the model if self.load_instance is True.
-            Update an existing row if specified in `self.instance` or loaded by primary key(s) in the data;
-            else create a new row.
+
+            Update an existing row if specified in `self.instance` or loaded by primary
+            key(s) in the data; else create a new row.
 
             :param data: Data to deserialize.
             """


### PR DESCRIPTION
This implements my FR, #379, making it possible to set `load_instance` when creating a schema instance.