### PR TITLE
Unwrap proxied columns when converting.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,15 @@ Changelog
 0.26.0 (unreleased)
 +++++++++++++++++++
 
+Bug fixes:
+
+* Unwrap proxied columns to handle models for subqueries (:issue:`383`).
+  Thanks :user:`mjpieters` for the catch and patch
+
+Other changes:
+
 * *Backwards-incompatible*: Remove deprecated ``ModelSchema`` and ``TableSchema`` classes.
+
 
 0.25.0 (2021-05-02)
 +++++++++++++++++++

--- a/src/marshmallow_sqlalchemy/convert.py
+++ b/src/marshmallow_sqlalchemy/convert.py
@@ -21,6 +21,14 @@ def _is_field(value):
     return isinstance(value, type) and issubclass(value, fields.Field)
 
 
+def _base_column(column):
+    """Unwrap proxied columns"""
+    if column not in column.base_columns and len(column.base_columns) == 1:
+        [base] = column.base_columns
+        return base
+    return column
+
+
 def _has_default(column):
     return (
         column.default is not None
@@ -259,7 +267,7 @@ class ModelConverter:
         if hasattr(prop, "direction"):
             field_cls = Related
         else:
-            column = prop.columns[0]
+            column = _base_column(prop.columns[0])
             field_cls = self._get_field_class_for_column(column)
         return field_cls
 
@@ -274,7 +282,7 @@ class ModelConverter:
     def _get_field_kwargs_for_property(self, prop):
         kwargs = self.get_base_kwargs()
         if hasattr(prop, "columns"):
-            column = prop.columns[0]
+            column = _base_column(prop.columns[0])
             self._add_column_kwargs(kwargs, column)
             prop = column
         if hasattr(prop, "direction"):  # Relationship property

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -128,6 +128,19 @@ class TestModelFieldConversion:
         assert "title" in fields
         assert "name" not in fields
 
+    def test_subquery_proxies(self, session, Base, models):
+        # Model from a subquery, columns are proxied.
+        # https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/383
+        first_graders = session.query(models.Student).filter(
+            models.Student.courses.any(models.Course.grade == 1)
+        )
+
+        class FirstGradeStudent(Base):
+            __table__ = first_graders.subquery("first_graders")
+
+        fields_ = fields_for_model(FirstGradeStudent)
+        assert fields_["dob"].allow_none is True
+
 
 def make_property(*column_args, **column_kwargs):
     return column_property(sa.Column(*column_args, **column_kwargs))


### PR DESCRIPTION
The columns of a model that is built from a sub-query are _proxies_ for the columns of the constituent tables. Unwrap these so the correct information can be extracted.

This fixes #383