### PR TITLE
Handle self._transient = False correctly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@ Bug fixes:
 
 * Unwrap proxied columns to handle models for subqueries (:issue:`383`).
   Thanks :user:`mjpieters` for the catch and patch
+* Fix setting ``transient`` on a per-instance basis when the
+  ``transient`` Meta option is set (:issue:`388`).
+  Thanks again :user:`mjpieters`.
 
 Other changes:
 

--- a/src/marshmallow_sqlalchemy/load_instance_mixin.py
+++ b/src/marshmallow_sqlalchemy/load_instance_mixin.py
@@ -29,7 +29,9 @@ class LoadInstanceMixin:
 
         @property
         def transient(self):
-            return self._transient or self.opts.transient
+            if self._transient is not None:
+                return self._transient
+            return self.opts.transient
 
         @transient.setter
         def transient(self, transient):

--- a/tests/test_sqlalchemy_schema.py
+++ b/tests/test_sqlalchemy_schema.py
@@ -438,6 +438,17 @@ class TestModelInstanceDeserialization:
         state = sa.inspect(load_data)
         assert state.transient
 
+    def test_override_transient(self, models, teacher):
+        # marshmallow-code/marshmallow-sqlalchemy#388
+        class TeacherSchema(SQLAlchemyAutoSchema):
+            class Meta:
+                model = models.Teacher
+                load_instance = True
+                transient = True
+
+        schema = TeacherSchema(transient=False)
+        assert schema.transient is False
+
 
 def test_related_when_model_attribute_name_distinct_from_column_name(
     models,


### PR DESCRIPTION
When locally set to False, and self.opt.transient set to True, the local value
is ignored. Only use the self.opts.transient value if no override was provided.

Fixes #388.