### PR TITLE
Unwrap functools.partial when introspecting field

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.26.1 (2021-06-05)
++++++++++++++++++++
+
+Bug fixes:
+
+* Fix generating fields for ``postgreql.ARRAY`` columns (:issue:`392`).
+ Thanks :user:`mjpieters` for the catch and patch.
+
 0.26.0 (2021-05-26)
 +++++++++++++++++++
 

--- a/src/marshmallow_sqlalchemy/convert.py
+++ b/src/marshmallow_sqlalchemy/convert.py
@@ -58,6 +58,10 @@ def _field_update_kwargs(field_class, field_kwargs, kwargs):
     if not kwargs:
         return field_kwargs
 
+    if isinstance(field_class, functools.partial):
+        # Unwrap partials, assuming that they bind a Field to arguments
+        field_class = field_class.func
+
     possible_field_keywords = {
         key
         for cls in inspect.getmro(field_class)

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -303,6 +303,20 @@ class TestFieldFor:
         field = field_for(models.Student, "full_name", validate=[])
         assert field.validators == []
 
+    def tests_postgresql_array_with_args(self, Base):
+        # regression test for #392
+        from sqlalchemy import Column, Integer, String
+        from sqlalchemy.dialects.postgresql import ARRAY
+
+        class ModelWithArray(Base):
+            __tablename__ = "model_with_array"
+            id = Column(Integer, primary_key=True)
+            bar = Column(ARRAY(String))
+
+        field = field_for(ModelWithArray, "bar", dump_only=True)
+        assert type(field) == fields.List
+        assert field.dump_only is True
+
 
 def _repr_validator_list(validators):
     return sorted([repr(validator) for validator in validators])


### PR DESCRIPTION
The `_postgres_array_factory()` function returns a partial, not a field class.

This fixes #392 