### PR TITLE
setup.py: Mark lazy-fixture>=0.6.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 INSTALL_REQUIRES = ("marshmallow>=3.0.0", "SQLAlchemy>=1.2.0")
 EXTRAS_REQUIRE = {
-    "tests": ["pytest", "pytest-lazy-fixture"],
+    "tests": ["pytest", "pytest-lazy-fixture>=0.6.2"],
     "lint": ["flake8==3.9.2", "flake8-bugbear==21.4.3", "pre-commit~=2.0"],
     "docs": ["sphinx==4.1.1", "alabaster==0.7.12", "sphinx-issues==1.2.0"],
 }


### PR DESCRIPTION
lazyfixture 0.6.2 is required to support pytest 5.6.0 and above.

Fixes https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/391