### PR TITLE
Handling column properties

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -40,3 +40,4 @@ Contributors
 - David Malakh `@Unix-Code <https://github.com/Unix-Code>`_
 - Martijn Pieters `@mjpieters <https://github.com/mjpieters>`_
 - Bruce Adams `@bruceadams <https://github.com/bruceadams>`_
+- Justin Crown `@mrname <https://github.com/mrname>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+0.28.0 (unreleased)
++++++++++++++++++++
+
+Features:
+
+* Add support for generating fields from `column_property` (:issue:`97`).
+  Thanks :user:`mrname` for the PR.
+
+Other changes:
+
+* Drop support for SQLAlchemy 1.2, which is EOL.
+
 0.27.0 (2021-12-18)
 +++++++++++++++++++
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,6 +90,14 @@ The following schema classes are equivalent to the above.
 
 Make sure to declare `Models` before instantiating `Schemas`. Otherwise `sqlalchemy.orm.configure_mappers() <https://docs.sqlalchemy.org/en/latest/orm/mapping_api.html>`_ will run too soon and fail.
 
+.. note::
+
+    Any `column_property` on the model that does not derive directly from `Column`
+    (such as a mapped expression), will be detected and marked as `dump_only`.
+
+    `hybrid_property` is not automatically handled at all, and would need to be
+    explicitly declared as a field.
+
 (De)serialize your data
 =======================
 
@@ -110,14 +118,6 @@ Make sure to declare `Models` before instantiating `Schemas`. Otherwise `sqlalch
     print(load_data)
     # <Author(name='Chuck Paluhniuk')>
 
-Complex Columns
-===============
-
-Any `column_property` on the model that does not derive directly from `Column`
-(such as a mapped expression), will be detected and marked as `dump_only`.
-
-`hybrid_property` is not automatically handled at all, and would need to be
-explicitly declared as a field.
 
 Get it now
 ==========

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -110,6 +110,15 @@ Make sure to declare `Models` before instantiating `Schemas`. Otherwise `sqlalch
     print(load_data)
     # <Author(name='Chuck Paluhniuk')>
 
+Complex Columns
+===============
+
+Any `column_property` on the model that does not derive directly from `Column`
+(such as a mapped expression), will be detected and marked as `dump_only`.
+
+`hybrid_property` is not automatically handled at all, and would need to be
+explicitly declared as a field.
+
 Get it now
 ==========
 ::

--- a/src/marshmallow_sqlalchemy/convert.py
+++ b/src/marshmallow_sqlalchemy/convert.py
@@ -317,9 +317,11 @@ class ModelConverter:
             if column.nullable:
                 kwargs["allow_none"] = True
             kwargs["required"] = not column.nullable and not _has_default(column)
-        # If there is no nullable attribute, we are dealing with a complex
-        # custom column (such as a column_property). In this case, assume
-        # dump_only and do not add validators moving forward
+        # If there is no nullable attribute, we are dealing with a property
+        # that does not derive from the Column class. Mark as dump_only.
+        # TODO - how does this work with hybrid_properties which can have
+        # setters? Should we be checking for isinstance(ColumnProperty)
+        # instead?
         else:
             kwargs["dump_only"] = True
 

--- a/src/marshmallow_sqlalchemy/convert.py
+++ b/src/marshmallow_sqlalchemy/convert.py
@@ -319,9 +319,6 @@ class ModelConverter:
             kwargs["required"] = not column.nullable and not _has_default(column)
         # If there is no nullable attribute, we are dealing with a property
         # that does not derive from the Column class. Mark as dump_only.
-        # TODO - how does this work with hybrid_properties which can have
-        # setters? Should we be checking for isinstance(ColumnProperty)
-        # instead?
         else:
             kwargs["dump_only"] = True
 

--- a/src/marshmallow_sqlalchemy/convert.py
+++ b/src/marshmallow_sqlalchemy/convert.py
@@ -313,17 +313,23 @@ class ModelConverter:
         """Add keyword arguments to kwargs (in-place) based on the passed in
         `Column <sqlalchemy.schema.Column>`.
         """
-        if column.nullable:
-            kwargs["allow_none"] = True
-        kwargs["required"] = not column.nullable and not _has_default(column)
+        if hasattr(column, "nullable"):
+            if column.nullable:
+                kwargs["allow_none"] = True
+            kwargs["required"] = not column.nullable and not _has_default(column)
+        # If there is no nullable attribute, we are dealing with a complex
+        # custom column (such as a column_property). In this case, assume
+        # dump_only and do not add validators moving forward
+        else:
+            kwargs["dump_only"] = True
 
-        if hasattr(column.type, "enums"):
+        if hasattr(column.type, "enums") and not kwargs.get("dump_only"):
             kwargs["validate"].append(validate.OneOf(choices=column.type.enums))
 
         # Add a length validator if a max length is set on the column
         # Skip UUID columns
         # (see https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/54)
-        if hasattr(column.type, "length"):
+        if hasattr(column.type, "length") and not kwargs.get("dump_only"):
             column_length = column.type.length
             if column_length is not None:
                 try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,12 @@ def models(Base):
             secondary=student_course,
             backref=backref("students", lazy="dynamic"),
         )
+        # Test complex column property
+        course_count = column_property(
+            sa.select(sa.func.count(student_course.c.course_id)).where(
+                student_course.c.student_id == id
+            )
+        )
 
         @property
         def url(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,9 +100,9 @@ def models(Base):
         )
         # Test complex column property
         course_count = column_property(
-            sa.select(sa.func.count(student_course.c.course_id)).where(
-                student_course.c.student_id == id
-            )
+            sa.select(sa.func.count(student_course.c.course_id))
+            .where(student_course.c.student_id == id)
+            .scalar_subquery()
         )
 
         @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,8 +100,9 @@ def models(Base):
         )
         # Test complex column property
         course_count = column_property(
-            sa.select([sa.func.count(student_course.c.course_id)])
-            .where(student_course.c.student_id == id)
+            sa.select([sa.func.count(student_course.c.course_id)]).where(
+                student_course.c.student_id == id
+            )
         )
 
         @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,9 +100,8 @@ def models(Base):
         )
         # Test complex column property
         course_count = column_property(
-            sa.select(sa.func.count(student_course.c.course_id))
+            sa.select([sa.func.count(student_course.c.course_id)])
             .where(student_course.c.student_id == id)
-            .scalar_subquery()
         )
 
         @property

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -244,6 +244,7 @@ class TestPropertyFieldConversion:
         prop = models.Student.__mapper__.get_property("course_count")
         field = converter.property2field(prop)
         assert type(field) is fields.Integer
+        assert field.dump_only is True
 
     def test_handle_simple_column_property(self, models, converter):
         """
@@ -252,6 +253,7 @@ class TestPropertyFieldConversion:
         prop = models.Seminar.__mapper__.get_property("label")
         field = converter.property2field(prop)
         assert type(field) is fields.String
+        assert field.dump_only is True
 
 
 class TestPropToFieldClass:

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -235,6 +235,19 @@ class TestPropertyFieldConversion:
         field = converter.property2field(prop)
         assert field.required is False
 
+    def test_handle_complex_column_property(self, models, converter):
+        """
+        Tests handling of column properties that do not derive directly from Column.
+        """
+        # A simple string column property
+        prop = models.Seminar.__mapper__.get_property("label")
+        field = converter.property2field(prop)
+        assert type(field) is fields.String
+        # A more complex column property, a mapped SQL expression
+        prop = models.Student.__mapper__.get_property("course_count")
+        field = converter.property2field(prop)
+        assert type(field) is fields.Integer
+
 
 class TestPropToFieldClass:
     def test_property2field(self):

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -235,18 +235,23 @@ class TestPropertyFieldConversion:
         field = converter.property2field(prop)
         assert field.required is False
 
-    def test_handle_complex_column_property(self, models, converter):
+    def test_handle_expression_based_column_property(self, models, converter):
         """
-        Tests handling of column properties that do not derive directly from Column.
+        Tests ability to handle a column_property with a mapped expression value.
+        Such properties should be marked as dump_only, and the type should be properly
+        inferred.
         """
-        # A simple string column property
-        prop = models.Seminar.__mapper__.get_property("label")
-        field = converter.property2field(prop)
-        assert type(field) is fields.String
-        # A more complex column property, a mapped SQL expression
         prop = models.Student.__mapper__.get_property("course_count")
         field = converter.property2field(prop)
         assert type(field) is fields.Integer
+
+    def test_handle_simple_column_property(self, models, converter):
+        """
+        Tests handling of column properties that do not derive directly from Column
+        """
+        prop = models.Seminar.__mapper__.get_property("label")
+        field = converter.property2field(prop)
+        assert type(field) is fields.String
 
 
 class TestPropToFieldClass:

--- a/tests/test_sqlalchemy_schema.py
+++ b/tests/test_sqlalchemy_schema.py
@@ -328,7 +328,13 @@ def test_auto_field_works_with_ordered_flag(models):
 
     schema = StudentSchema()
     # Declared fields precede auto-generated fields
-    assert tuple(schema.fields.keys()) == ("full_name", "id", "dob", "date_created")
+    assert tuple(schema.fields.keys()) == (
+        "full_name",
+        "course_count",
+        "id",
+        "dob",
+        "date_created",
+    )
 
 
 class TestAliasing:

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     marshmallow3: marshmallow>=3.0.0,<4.0.0
     marshmallowdev: https://github.com/marshmallow-code/marshmallow/archive/dev.tar.gz
     lowest: marshmallow==3.0.0
-    lowest: sqlalchemy==1.2.0
+    lowest: sqlalchemy==1.3.0
 commands = pytest {posargs}
 
 [testenv:lint]


### PR DESCRIPTION
While looking into https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/97 I realized that the column properties do indeed have an inferred type.

This is a POC of how we could handle column properties, by marking them as `dump_only` and skipping things that relate only to writable columns (like validators). If the approach makes sense to you @sloria I can clean this up and submit an actual PR for review.