### PR TITLE
Use packaging library to avoid DeprecationWarning from distutils

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   - id: pyupgrade
     args: [--py37-plus]
 - repo: https://github.com/python/black
-  rev: 22.1.0
+  rev: 22.3.0
   hooks:
   - id: black
     language_version: python3

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -41,3 +41,4 @@ Contributors
 - Martijn Pieters `@mjpieters <https://github.com/mjpieters>`_
 - Bruce Adams `@bruceadams <https://github.com/bruceadams>`_
 - Justin Crown `@mrname <https://github.com/mrname>`_
+- Jeppe Fihl-Pearson  `@Tenzer <https://github.com/Tenzer>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.28.1 (unreleased)
++++++++++++++++++++
+
+Bug fixes:
+
+* Address ``DeprecationWarning`` re: usage of ``distutils`` (:pr:`435`).
+ Thanks :user:`Tenzer` for the PR.
+
 0.28.0 (2022-03-09)
 +++++++++++++++++++
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 
 from setuptools import find_packages, setup
 
-INSTALL_REQUIRES = ("marshmallow>=3.0.0", "SQLAlchemy>=1.3.0")
+INSTALL_REQUIRES = ("marshmallow>=3.0.0", "SQLAlchemy>=1.3.0", "packaging>=21.3")
 EXTRAS_REQUIRE = {
     "tests": ["pytest", "pytest-lazy-fixture>=0.6.2"],
     "lint": ["flake8==4.0.1", "flake8-bugbear==22.3.23", "pre-commit~=2.0"],

--- a/src/marshmallow_sqlalchemy/convert.py
+++ b/src/marshmallow_sqlalchemy/convert.py
@@ -1,11 +1,11 @@
 import inspect
 import functools
 import warnings
-from distutils.version import LooseVersion
 
 import uuid
 import marshmallow as ma
 from marshmallow import validate, fields
+from packaging.version import Version
 from sqlalchemy.dialects import postgresql, mysql, mssql
 from sqlalchemy.orm import SynonymProperty
 import sqlalchemy as sa
@@ -14,7 +14,7 @@ from .exceptions import ModelConversionError
 from .fields import Related, RelatedList
 
 
-_META_KWARGS_DEPRECATED = LooseVersion(ma.__version__) >= LooseVersion("3.10.0")
+_META_KWARGS_DEPRECATED = Version(ma.__version__) >= Version("3.10.0")
 
 
 def _is_field(value):


### PR DESCRIPTION
`distutils.version.LooseVersion` has been deprecated since https://github.com/pypa/distutils/pull/75.

This instead replaces that with `packaging.version.Version` from the [packaging library](https://packaging.pypa.io/en/latest/).