### PR TITLE
fix #336: detecting relationship as nullable=False

### DIFF
--- a/src/marshmallow_sqlalchemy/convert.py
+++ b/src/marshmallow_sqlalchemy/convert.py
@@ -349,7 +349,7 @@ class ModelConverter:
         nullable = True
         for pair in prop.local_remote_pairs:
             if not pair[0].nullable:
-                if prop.uselist is True:
+                if prop.uselist is True or prop.direction.name == "MANYTOONE":
                     nullable = False
                 break
         kwargs.update({"allow_none": nullable, "required": not nullable})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,7 +194,7 @@ def models(Base):
         seminar = relationship(
             Seminar, foreign_keys=[seminar_title, seminar_semester], backref="lectures"
         )
-        kw = relationship("Keyword", secondary=lecturekeywords_table)
+        kw = relationship("Keyword", uselist=False, secondary=lecturekeywords_table)
         keywords = association_proxy(
             "kw", "keyword", creator=lambda kw: Keyword(keyword=kw)
         )

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -354,6 +354,49 @@ class TestFieldFor:
         assert field.dump_only is True
 
 
+class TestRelationshipKwarg:
+    def test_many_to_one_relationship_kwarg(self, models):
+        default_converter = ModelConverter()
+
+        rel = models.Student.__mapper__.attrs.get("current_school")
+        assert rel.direction.name == "MANYTOONE"
+        assert rel.uselist is False
+        rel_kwargs = {}
+        default_converter._add_relationship_kwargs(rel_kwargs, rel)
+        assert rel_kwargs["allow_none"] is False
+        assert rel_kwargs["required"] is True
+
+        rel = models.School.__mapper__.attrs.get("students")
+        assert rel.direction.name == "ONETOMANY"
+        assert rel.uselist is True
+        rel_kwargs = {}
+        default_converter._add_relationship_kwargs(rel_kwargs, rel)
+        assert rel_kwargs["allow_none"] is False
+        assert rel_kwargs["required"] is True
+
+    def test_many_to_many_with_uselist_relationship_kwarg(self, models):
+        default_converter = ModelConverter()
+
+        rel = models.Student.__mapper__.attrs.get("courses")
+        assert rel.direction.name == "MANYTOMANY"
+        assert rel.uselist is True
+        rel_kwargs = {}
+        default_converter._add_relationship_kwargs(rel_kwargs, rel)
+        assert rel_kwargs["allow_none"] is False
+        assert rel_kwargs["required"] is True
+
+    def test_many_to_many_without_uselist_relationship_kwarg(self, models):
+        default_converter = ModelConverter()
+
+        rel = models.Lecture.__mapper__.attrs.get("kw")
+        assert rel.direction.name == "MANYTOMANY"
+        assert rel.uselist is False
+        rel_kwargs = {}
+        default_converter._add_relationship_kwargs(rel_kwargs, rel)
+        assert rel_kwargs["allow_none"] is True
+        assert rel_kwargs["required"] is False
+
+
 def _repr_validator_list(validators):
     return sorted(repr(validator) for validator in validators)
 


### PR DESCRIPTION
Attempt to address #336,

using direction mapping to decide if nullable is to be set False or not

pytest result for new branch: `94 passed, 55 warnings`
pytest in master :  `94 passed, 55 warnings`

