### PR TITLE
fix #459: using .scalar_subquery() for SQLA>1.4

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -42,3 +42,4 @@ Contributors
 - Bruce Adams `@bruceadams <https://github.com/bruceadams>`_
 - Justin Crown `@mrname <https://github.com/mrname>`_
 - Jeppe Fihl-Pearson  `@Tenzer <https://github.com/Tenzer>`_
+- Indivar  `@indiVar0508 <https://github.com/indiVar0508>`_

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,12 +98,16 @@ def models(Base):
             secondary=student_course,
             backref=backref("students", lazy="dynamic"),
         )
+
         # Test complex column property
-        course_count = column_property(
-            sa.select([sa.func.count(student_course.c.course_id)]).where(
-                student_course.c.student_id == id
-            )
+        subquery = sa.select([sa.func.count(student_course.c.course_id)]).where(
+            student_course.c.student_id == id
         )
+        if hasattr(subquery, "scalar_subquery"):
+            subquery = subquery.scalar_subquery()
+        else:  # SQLA < 1.4
+            subquery = subquery.as_scalar()
+        course_count = column_property(subquery)
 
         @property
         def url(self):


### PR DESCRIPTION
Attempt to address #459 ,

Using scalar_subquery available from SQLA>1.4 