### PR TITLE
fix 332: to address column typo asper doc

### DIFF
--- a/src/marshmallow_sqlalchemy/fields.py
+++ b/src/marshmallow_sqlalchemy/fields.py
@@ -1,3 +1,4 @@
+import warnings
 from marshmallow import fields
 from marshmallow.utils import is_iterable_but_not_string
 
@@ -41,9 +42,17 @@ class Related(fields.Field):
         "expected a dictionary with keys {keys!r}"
     }
 
-    def __init__(self, column=None, **kwargs):
+    def __init__(self, columns=None, column=None, **kwargs):
+        if column is not None:
+            warnings.warn(
+                "`column` parameter is deprecated and will be removed in future releases. "
+                "Use `columns` instead.",
+                DeprecationWarning,
+            )
+            if columns is None:
+                columns = column
         super().__init__(**kwargs)
-        self.columns = ensure_list(column or [])
+        self.columns = ensure_list(columns or [])
 
     @property
     def model(self):

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -313,6 +313,22 @@ class TestFieldFor:
         field = field_for(models.Student, "full_name", field_class=fields.Date)
         assert type(field) == fields.Date
 
+    def test_related_initialization_warning(self, models, session):
+        with pytest.warns(
+            DeprecationWarning,
+            match="column` parameter is deprecated and will be removed in future releases. Use `columns` instead.",
+        ):
+            Related(column=[])
+
+    def test_related_initialization_with_columns(self, models, session):
+        ret = Related(columns=["TestCol"])
+        assert len(ret.columns) == 1
+        assert ret.columns[0] == "TestCol"
+        ret = Related(columns="TestCol")
+        assert isinstance(ret.columns, list)
+        assert len(ret.columns) == 1
+        assert ret.columns[0] == "TestCol"
+
     def test_field_for_can_override_validators(self, models, session):
         field = field_for(
             models.Student, "full_name", validate=[validate.Length(max=20)]


### PR DESCRIPTION
Attempt to address #332 ,

based on API [documentation](https://marshmallow-sqlalchemy.readthedocs.io/en/latest/api_reference.html#marshmallow_sqlalchemy.fields.Related) parameters section asks for columns but class parameter accepts column.

added a deprecation warning for column with message to use columns instead 