### PR TITLE
use marshmallow 3.18.0 Enum field if available

### DIFF
--- a/src/marshmallow_sqlalchemy/convert.py
+++ b/src/marshmallow_sqlalchemy/convert.py
@@ -83,7 +83,8 @@ class ModelConverter:
     """
 
     SQLA_TYPE_MAPPING = {
-        sa.Enum: fields.Field,
+        # marshmallow 3.18.0 adds native Enum support
+        sa.Enum: getattr(fields, "Enum", fields.Field),
         sa.JSON: fields.Raw,
         postgresql.BIT: fields.Integer,
         postgresql.OID: fields.Integer,


### PR DESCRIPTION
marshmallow 3.18.0 now has native Enum support. This PR updates the `SQLA_TYPE_MAPPING` to use the new field if it is available