### PR TITLE
Manually make the call to _check_configure that was removed in SQLAlc…

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -43,3 +43,4 @@ Contributors
 - Justin Crown `@mrname <https://github.com/mrname>`_
 - Jeppe Fihl-Pearson  `@Tenzer <https://github.com/Tenzer>`_
 - Indivar  `@indiVar0508 <https://github.com/indiVar0508>`_
+- Lloyd Capson `@LloydCapson <https://github.com/LloydCapson>`_

--- a/src/marshmallow_sqlalchemy/convert.py
+++ b/src/marshmallow_sqlalchemy/convert.py
@@ -132,6 +132,11 @@ class ModelConverter:
     ):
         result = dict_cls()
         base_fields = base_fields or {}
+
+        # Manually calling _check_configure(), replacing the call that used to 
+        # be done in model.__mapper__.iterate_properties prior to SQLAlchemy 2.0.2.
+        model.__mapper__._check_configure()
+
         for prop in model.__mapper__.iterate_properties:
             key = self._get_field_name(prop)
             if self._should_exclude_field(prop, fields=fields, exclude=exclude):

--- a/src/marshmallow_sqlalchemy/convert.py
+++ b/src/marshmallow_sqlalchemy/convert.py
@@ -133,7 +133,7 @@ class ModelConverter:
         result = dict_cls()
         base_fields = base_fields or {}
 
-        # Manually calling _check_configure(), replacing the call that used to 
+        # Manually calling _check_configure(), replacing the call that used to
         # be done in model.__mapper__.iterate_properties prior to SQLAlchemy 2.0.2.
         model.__mapper__._check_configure()
 


### PR DESCRIPTION
…hemy 2.0.2

I simply call _check_configure() before returning from iterate_properties. This is exactly what happened prior to the _check_configure().