### PR TITLE
Only lint in GHA on tag

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-python@v4.3.0
         with:
           python-version: '3.11'
-      - run: python -m pip install --upgrade pip wheel
+      - run: python -m pip install --upgrade pip
       - run: pip install tox
       - run: tox -elint
   tests:
@@ -30,10 +30,9 @@ jobs:
       - uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python }}
-      - run: python -m pip install --upgrade pip wheel
-      - run: pip install tox codecov
+      - run: python -m pip install --upgrade pip
+      - run: pip install tox
       - run: tox -e${{ matrix.tox }}
-      - run: codecov
   release:
     needs: [lint, tests]
     name: PyPI release

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -3,17 +3,6 @@ on:
   push:
   pull_request:
 jobs:
-  lint:
-    name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3.1.0
-      - uses: actions/setup-python@v4.3.0
-        with:
-          python-version: '3.11'
-      - run: python -m pip install --upgrade pip
-      - run: pip install tox
-      - run: tox -elint
   tests:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -31,17 +20,34 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: python -m pip install --upgrade pip
-      - run: pip install tox
-      - run: tox -e${{ matrix.tox }}
+      - run: python -m pip install tox
+      - run: python -m tox -e${{ matrix.tox }}
+  # this duplicates pre-commit.ci, so only run it on tags
+  # it guarantees that linting is passing prior to a release
+  lint-pre-release:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-python@v4.3.0
+        with:
+          python-version: '3.11'
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install tox
+      - run: python -m tox -elint
   release:
-    needs: [lint, tests]
+    needs: [tests, lint-pre-release]
     name: PyPI release
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-python@v4.3.0
-      - run: python -m pip install --upgrade pip wheel
-      - run: pip install twine
-      - run: python setup.py sdist bdist_wheel
-      - run: twine upload -u __token__ -p ${{ secrets.PYPI_API_TOKEN }} dist/*
+      - name: install requirements
+        run: python -m pip install build twine
+      - name: build dists
+        run: python -m build
+      - name: check package metadata
+        run: twine check dist/*
+      - name: publish
+        run: twine upload -u __token__ -p ${{ secrets.PYPI_API_TOKEN }} dist/*

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
     lint
-    py{37,38,39,310,3.11}-marshmallow3
+    py{37,38,39,310,311}-marshmallow3
     py311-marshmallowdev
     py37-lowest
     docs


### PR DESCRIPTION
Same as webargs, marshmallow.

Lint is done with pre-commit CI. Only perform lint with GHA on tag to prevent releases slipping through.