### PR TITLE
Drop SQLAlchemy 1.3 / Fix SQLAlchemy 2.0 compatibility warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 INSTALL_REQUIRES = (
     "marshmallow>=3.0.0",
-    "SQLAlchemy>=1.3.0,<2.0",
+    "SQLAlchemy>=1.4.40,<2.0",
     "packaging>=21.3",
 )
 EXTRAS_REQUIRE = {

--- a/src/marshmallow_sqlalchemy/fields.py
+++ b/src/marshmallow_sqlalchemy/fields.py
@@ -114,9 +114,13 @@ class Related(fields.Field):
         :raises NoResultFound: if there is no matching record.
         """
         if self.columns:
-            result = self.session.query(related_model).filter_by(
-                **{prop.key: value.get(prop.key) for prop in self.related_keys}
-            ).one()
+            result = (
+                self.session.query(related_model)
+                .filter_by(
+                    **{prop.key: value.get(prop.key) for prop in self.related_keys}
+                )
+                .one()
+            )
         else:
             # Use a faster path if the related key is the primary key.
             lookup_values = [value.get(prop.key) for prop in self.related_keys]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,10 +101,7 @@ def models(Base):
         subquery = sa.select(sa.func.count(student_course.c.course_id)).where(
             student_course.c.student_id == id
         )
-        if hasattr(subquery, "scalar_subquery"):
-            subquery = subquery.scalar_subquery()
-        else:  # SQLA < 1.4
-            subquery = subquery.as_scalar()
+        subquery = subquery.scalar_subquery()
         course_count = column_property(subquery)
 
         @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,7 @@ import datetime as dt
 import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, relationship, backref, column_property, synonym
+from sqlalchemy.orm import sessionmaker, relationship, backref, column_property, synonym, declarative_base
 
 
 class AnotherInteger(sa.Integer):
@@ -27,14 +26,14 @@ def Base():
 
 @pytest.fixture()
 def engine():
-    return sa.create_engine("sqlite:///:memory:", echo=False)
+    return sa.create_engine("sqlite:///:memory:", echo=False, future=True)
 
 
 @pytest.fixture()
 def session(Base, models, engine):
     Session = sessionmaker(bind=engine)
     Base.metadata.create_all(bind=engine)
-    return Session()
+    return Session(future=True)
 
 
 @pytest.fixture()
@@ -99,7 +98,7 @@ def models(Base):
         )
 
         # Test complex column property
-        subquery = sa.select([sa.func.count(student_course.c.course_id)]).where(
+        subquery = sa.select(sa.func.count(student_course.c.course_id)).where(
             student_course.c.student_id == id
         )
         if hasattr(subquery, "scalar_subquery"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,14 @@ import datetime as dt
 import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.orm import sessionmaker, relationship, backref, column_property, synonym, declarative_base
+from sqlalchemy.orm import (
+    sessionmaker,
+    relationship,
+    backref,
+    column_property,
+    synonym,
+    declarative_base,
+)
 
 
 class AnotherInteger(sa.Integer):

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     marshmallow3: marshmallow>=3.0.0,<4.0.0
     marshmallowdev: https://github.com/marshmallow-code/marshmallow/archive/dev.tar.gz
     lowest: marshmallow==3.0.0
-    lowest: sqlalchemy==1.3.0
+    lowest: sqlalchemy==1.4.40
 commands = pytest {posargs}
 
 [testenv:lint]


### PR DESCRIPTION
Require SQLAlchemy 1.4.40

The choice of 1.4.40 is kind of arbitrary. It shouldn't be an issue. The point is that a recent 1.4.x will make the transition easier because older 1.4.x don't have all pre-2.0 changes and require more conditional code. Recent 1.4.x are more 2.0 compliant.

This PR fixes 2.0 compat warnings.