### PR TITLE
SQLAlchemy 2 - Fix missing implicit calls to registry.configure()

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -43,3 +43,4 @@ Contributors
 - Justin Crown `@mrname <https://github.com/mrname>`_
 - Jeppe Fihl-Pearson  `@Tenzer <https://github.com/Tenzer>`_
 - Indivar  `@indiVar0508 <https://github.com/indiVar0508>`_
+- David Doyon  `@ddoyon92 <https://github.com/ddoyon92>`_

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -109,7 +109,7 @@ You can also use `marshmallow_sqlalchemy's` conversion functions directly.
 
     from marshmallow_sqlalchemy import property2field
 
-    id_prop = Author.__mapper__.get_property("id")
+    id_prop = Author.__mapper__.attrs.get("id")
 
     property2field(id_prop)
     # <fields.Integer(default=<marshmallow.missing>, ...>

--- a/src/marshmallow_sqlalchemy/convert.py
+++ b/src/marshmallow_sqlalchemy/convert.py
@@ -132,7 +132,8 @@ class ModelConverter:
     ):
         result = dict_cls()
         base_fields = base_fields or {}
-        for prop in model.__mapper__.iterate_properties:
+
+        for prop in model.__mapper__.attrs:
             key = self._get_field_name(prop)
             if self._should_exclude_field(prop, fields=fields, exclude=exclude):
                 # Allow marshmallow to validate and exclude the field key.
@@ -225,7 +226,7 @@ class ModelConverter:
             target_model = attr.target_class
             prop_name = attr.value_attr
             remote_with_local_multiplicity = attr.local_attr.prop.uselist
-        prop = target_model.__mapper__.get_property(prop_name)
+        prop = target_model.__mapper__.attrs.get(prop_name)
         converted_prop = self.property2field(prop, **kwargs)
         if remote_with_local_multiplicity:
             related_list_kwargs = _field_update_kwargs(

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -231,7 +231,7 @@ class TestPropertyFieldConversion:
         assert field.required is False
 
     def test_convert_autoincrement(self, models, converter):
-        prop = models.Course.__mapper__.get_property("id")
+        prop = models.Course.__mapper__.attrs.get("id")
         field = converter.property2field(prop)
         assert field.required is False
 
@@ -241,7 +241,7 @@ class TestPropertyFieldConversion:
         Such properties should be marked as dump_only, and the type should be properly
         inferred.
         """
-        prop = models.Student.__mapper__.get_property("course_count")
+        prop = models.Student.__mapper__.attrs.get("course_count")
         field = converter.property2field(prop)
         assert type(field) is fields.Integer
         assert field.dump_only is True
@@ -250,7 +250,7 @@ class TestPropertyFieldConversion:
         """
         Tests handling of column properties that do not derive directly from Column
         """
-        prop = models.Seminar.__mapper__.get_property("label")
+        prop = models.Seminar.__mapper__.attrs.get("label")
         field = converter.property2field(prop)
         assert type(field) is fields.String
         assert field.dump_only is True


### PR DESCRIPTION
Remove calls to mapper.iterate_properties and mapper.get_property() which do not make implicit call to registry.configure() anymore, causing issues with relationships mapping.

Closes https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/487

