### PR TITLE
Use Session.get() in `get_instance` instead of Session.query()

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -44,3 +44,4 @@ Contributors
 - Jeppe Fihl-Pearson  `@Tenzer <https://github.com/Tenzer>`_
 - Indivar  `@indiVar0508 <https://github.com/indiVar0508>`_
 - David Doyon  `@ddoyon92 <https://github.com/ddoyon92>`_
+- Hippolyte Henry `@zippolyte <https://github.com/zippolyte>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 0.30.0 (unreleased)
 +++++++++++++++++++
 
+Features:
+
+* Use ``Session.get()`` load instances to improve deserialization performance (:pr:`548`).
+  Thanks :user:`zippolyte` for the PR.
+
 Other changes:
 
 * Drop support for Python 3.7, which is EOL (:pr:`540`).

--- a/src/marshmallow_sqlalchemy/load_instance_mixin.py
+++ b/src/marshmallow_sqlalchemy/load_instance_mixin.py
@@ -6,6 +6,7 @@
     Users should not need to use this module directly.
 """
 import marshmallow as ma
+from sqlalchemy.orm.exc import ObjectDeletedError
 
 from .fields import get_primary_keys
 
@@ -55,7 +56,10 @@ class LoadInstanceMixin:
             props = get_primary_keys(self.opts.model)
             filters = {prop.key: data.get(prop.key) for prop in props}
             if None not in filters.values():
-                return self.session.query(self.opts.model).filter_by(**filters).first()
+                try:
+                    return self.session.get(self.opts.model, filters)
+                except ObjectDeletedError:
+                    return None
             return None
 
         @ma.post_load


### PR DESCRIPTION
Session.get() ([SQLA docs](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.get)) tries to fetch an object from the session's identity map if it exists, and performs a SQL query otherwise. 

This improves `load()` performance by reducing number of SQL queries, especially for nested relationships, if everything is already available into the session.