### PR TITLE
Move to pytest-lazy-fixtures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,7 @@ Source = "https://github.com/marshmallow-code/marshmallow-sqlalchemy"
 
 [project.optional-dependencies]
 docs = ["sphinx==7.4.5", "alabaster==1.0.0", "sphinx-issues==4.1.0"]
-# TODO: Remove pytest pin when https://github.com/TvoroG/pytest-lazy-fixture/issues/65 is resolved
-tests = ["pytest<8", "pytest-lazy-fixture>=0.6.2"]
+tests = ["pytest", "pytest-lazy-fixtures"]
 dev = ["marshmallow-sqlalchemy[tests]", "tox", "pre-commit~=3.5"]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ Source = "https://github.com/marshmallow-code/marshmallow-sqlalchemy"
 
 [project.optional-dependencies]
 docs = ["sphinx==7.4.5", "alabaster==1.0.0", "sphinx-issues==4.1.0"]
-tests = ["pytest", "pytest-lazy-fixtures"]
+tests = ["pytest<9", "pytest-lazy-fixtures"]
 dev = ["marshmallow-sqlalchemy[tests]", "tox", "pre-commit~=3.5"]
 
 [build-system]

--- a/tests/test_sqlalchemy_schema.py
+++ b/tests/test_sqlalchemy_schema.py
@@ -1,8 +1,8 @@
 import marshmallow
 import pytest
-from pytest_lazy_fixtures import lf
 import sqlalchemy as sa
 from marshmallow import Schema, ValidationError, validate
+from pytest_lazy_fixtures import lf
 
 from marshmallow_sqlalchemy import SQLAlchemyAutoSchema, SQLAlchemySchema, auto_field
 from marshmallow_sqlalchemy.exceptions import IncorrectSchemaTypeError

--- a/tests/test_sqlalchemy_schema.py
+++ b/tests/test_sqlalchemy_schema.py
@@ -1,5 +1,6 @@
 import marshmallow
 import pytest
+from pytest_lazy_fixtures import lf
 import sqlalchemy as sa
 from marshmallow import Schema, ValidationError, validate
 
@@ -125,8 +126,8 @@ def sqla_auto_model_schema_with_fks(models, request):
 @pytest.mark.parametrize(
     "schema",
     (
-        pytest.lazy_fixture("sqla_schema_with_relationships"),
-        pytest.lazy_fixture("sqla_auto_model_schema_with_relationships"),
+        lf("sqla_schema_with_relationships"),
+        lf("sqla_auto_model_schema_with_relationships"),
     ),
 )
 def test_dump_with_relationships(teacher, schema):
@@ -141,8 +142,8 @@ def test_dump_with_relationships(teacher, schema):
 @pytest.mark.parametrize(
     "schema",
     (
-        pytest.lazy_fixture("sqla_schema_with_fks"),
-        pytest.lazy_fixture("sqla_auto_model_schema_with_fks"),
+        lf("sqla_schema_with_fks"),
+        lf("sqla_auto_model_schema_with_fks"),
     ),
 )
 def test_dump_with_foreign_keys(teacher, schema):
@@ -163,10 +164,10 @@ def test_table_schema_dump(teacher, sqla_auto_table_schema):
 @pytest.mark.parametrize(
     "schema",
     (
-        pytest.lazy_fixture("sqla_schema_with_relationships"),
-        pytest.lazy_fixture("sqla_schema_with_fks"),
-        pytest.lazy_fixture("sqla_auto_model_schema"),
-        pytest.lazy_fixture("sqla_auto_table_schema"),
+        lf("sqla_schema_with_relationships"),
+        lf("sqla_schema_with_fks"),
+        lf("sqla_auto_model_schema"),
+        lf("sqla_auto_table_schema"),
     ),
 )
 def test_load(schema):
@@ -217,10 +218,10 @@ class TestLoadInstancePerSchemaInstance:
     @pytest.mark.parametrize(
         "Schema",
         (
-            pytest.lazy_fixture("schema_no_load_instance"),
-            pytest.lazy_fixture("schema_with_load_instance"),
-            pytest.lazy_fixture("auto_schema_no_load_instance"),
-            pytest.lazy_fixture("auto_schema_with_load_instance"),
+            lf("schema_no_load_instance"),
+            lf("schema_with_load_instance"),
+            lf("auto_schema_no_load_instance"),
+            lf("auto_schema_with_load_instance"),
         ),
     )
     def test_toggle_load_instance_per_schema(self, models, Schema):
@@ -246,10 +247,10 @@ class TestLoadInstancePerSchemaInstance:
 @pytest.mark.parametrize(
     "schema",
     (
-        pytest.lazy_fixture("sqla_schema_with_relationships"),
-        pytest.lazy_fixture("sqla_schema_with_fks"),
-        pytest.lazy_fixture("sqla_auto_model_schema"),
-        pytest.lazy_fixture("sqla_auto_table_schema"),
+        lf("sqla_schema_with_relationships"),
+        lf("sqla_schema_with_fks"),
+        lf("sqla_auto_model_schema"),
+        lf("sqla_auto_table_schema"),
     ),
 )
 def test_load_validation_errors(schema):
@@ -373,8 +374,8 @@ class TestAliasing:
     @pytest.mark.parametrize(
         "schema",
         (
-            pytest.lazy_fixture("aliased_schema"),
-            pytest.lazy_fixture("aliased_auto_schema"),
+            lf("aliased_schema"),
+            lf("aliased_auto_schema"),
         ),
     )
     def test_passing_column_name(self, schema, teacher):
@@ -417,8 +418,8 @@ class TestModelInstanceDeserialization:
     @pytest.mark.parametrize(
         "SchemaClass",
         (
-            pytest.lazy_fixture("sqla_schema_class"),
-            pytest.lazy_fixture("sqla_auto_schema_class"),
+            lf("sqla_schema_class"),
+            lf("sqla_auto_schema_class"),
         ),
     )
     def test_load(self, teacher, SchemaClass, models):


### PR DESCRIPTION
pytest-lazy-fixture seems to be abandoned upstream. This PR replaces it with the maintained pytest-lazy-fixtures, which also works with pytest 8.x.