### PR TITLE
Fix #485: support `marshmallow.fields.Enum`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -46,3 +46,4 @@ Contributors
 - David Doyon  `@ddoyon92 <https://github.com/ddoyon92>`_
 - Hippolyte Henry `@zippolyte <https://github.com/zippolyte>`_
 - Alexandre Detiste tchet@debian.org
+- PandaByte `@panda-byte <https://github.com/panda-byte>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+1.1.0 (unreleased)
+++++++++++++++++++
+
+Features:
+
+*  ``sqlalchemy.Enum`` fields generate a corresponding ``marshmallow.fields.Enum`` field
+  (:issue:`485`, :issue:`112`). Thanks :user:`panda-byte` for the PR.
+
+Support:
+
+* Drop support for marshmallow<=3.18.0.
+
 1.0.0 (2024-01-30)
 +++++++++++++++++++
 

--- a/README.rst
+++ b/README.rst
@@ -119,7 +119,7 @@ Get it now
    pip install -U marshmallow-sqlalchemy
 
 
-Requires Python >= 3.8, marshmallow >= 3.0.0, and SQLAlchemy >= 1.4.40.
+Requires Python >= 3.8, marshmallow >= 3.18.0, and SQLAlchemy >= 1.4.40.
 
 Documentation
 =============

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -125,7 +125,7 @@ Get it now
 
    pip install -U marshmallow-sqlalchemy
 
-Requires Python >= 3.8, marshmallow >= 3.0.0, and SQLAlchemy >= 1.4.40.
+Requires Python >= 3.8, marshmallow >= 3.18.0, and SQLAlchemy >= 1.4.40.
 
 Learn
 =====

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 requires-python = ">=3.8"
-dependencies = ["marshmallow>=3.10.0", "SQLAlchemy>=1.4.40,<3.0"]
+dependencies = ["marshmallow>=3.18.0", "SQLAlchemy>=1.4.40,<3.0"]
 
 [project.urls]
 Changelog = "https://marshmallow-sqlalchemy.readthedocs.io/en/latest/changelog.html"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from enum import Enum
 from types import SimpleNamespace
 
 import pytest
@@ -61,6 +62,7 @@ def models(Base):
         cost = sa.Column(sa.Numeric(5, 2), nullable=False)
         description = sa.Column(sa.Text, nullable=True)
         level = sa.Column(sa.Enum("Primary", "Secondary"))
+        level_with_enum_class = sa.Column(sa.Enum(Enum("Level", "PRIMARY SECONDARY")))
         has_prereqs = sa.Column(sa.Boolean, nullable=False)
         started = sa.Column(sa.DateTime, nullable=False)
         grade = sa.Column(AnotherInteger, nullable=False)

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -73,6 +73,12 @@ class TestModelFieldConversion:
         assert validator
         assert list(validator.choices) == ["Primary", "Secondary"]
 
+    def test_sets_enum_with_class_choices(self, models):
+        fields_ = fields_for_model(models.Course)
+        validator = contains_validator(fields_["level_with_enum_class"], validate.OneOf)
+        assert validator
+        assert list(validator.choices) == ["PRIMARY", "SECONDARY"]
+
     def test_many_to_many_relationship(self, models):
         student_fields = fields_for_model(models.Student, include_relationships=True)
         assert type(student_fields["courses"]) is RelatedList

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,9 @@ envlist=
 [testenv]
 extras = tests
 deps =
-    marshmallow3: marshmallow>=3.10.0,<4.0.0
+    marshmallow3: marshmallow>=3.18.0,<4.0.0
     marshmallowdev: https://github.com/marshmallow-code/marshmallow/archive/dev.tar.gz
-    lowest: marshmallow==3.10.0
+    lowest: marshmallow==3.18.0
     lowest: sqlalchemy==1.4.40
 commands = pytest {posargs}
 


### PR DESCRIPTION
[`marshmallow.fields.Enum`](https://marshmallow.readthedocs.io/en/stable/marshmallow.fields.html#marshmallow.fields.Enum) was introduced in version 3.18.0 of marshmallow (around 2 years ago), but currently, the model converter still maps [`sqlalchemy.sql.sqltypes.Enum`](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Enum) to a plain [`marshmallow.fields.Field`](https://marshmallow.readthedocs.io/en/stable/marshmallow.fields.html#marshmallow.fields.Field). This causes issues, such as  #485.

This pull request adds a mapping from `sa.Enum` to `ma.fields.Enum`, if an [`enum.Enum`](enum.Enum) class was used for initialization, otherwise (for string choices supplied to `sa.Enum`) `ma.fields.Field` is still used, and the correct `enum` argument is passed. A test for using an enum field with a class was added. It also bumps up the required marshmallow dependency version to 3.18.0.

All pytest and tox tests did pass.

[!470](https://github.com/marshmallow-code/marshmallow-sqlalchemy/pull/470) also addressed this issue, but it doesn't work (anymore?), because the instantiation of `ma.fields.Enum` requires a positional `enum` argument, which isn't supplied.