### PR TITLE
Unsilence warnings; ensure proper test cleanup

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-filterwarnings =
-    ignore:.*Binary.*:sqlalchemy.exc.SADeprecationWarning
-    ignore:.*Decimal.*:sqlalchemy.exc.SAWarning
-    ignore:.*Passing `info=*:DeprecationWarning

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,14 +44,17 @@ def Base() -> type:
 
 @pytest.fixture()
 def engine():
-    return sa.create_engine("sqlite:///:memory:", echo=False, future=True)
+    engine = sa.create_engine("sqlite:///:memory:", echo=False, future=True)
+    yield engine
+    engine.dispose()
 
 
 @pytest.fixture()
 def session(Base, models, engine):
     Session = sessionmaker(bind=engine)
     Base.metadata.create_all(bind=engine)
-    return Session(future=True)
+    with Session() as session:
+        yield session
 
 
 CourseLevel = Enum("CourseLevel", "PRIMARY SECONDARY")

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -279,7 +279,9 @@ class TestPropToFieldClass:
 
     def test_can_pass_extra_kwargs(self):
         prop = make_property(sa.String())
-        field = property2field(prop, instance=True, description="just a string")
+        field = property2field(
+            prop, instance=True, metadata=dict(description="just a string")
+        )
         assert field.metadata["description"] == "just a string"
 
 
@@ -295,7 +297,9 @@ class TestColumnToFieldClass:
 
     def test_can_pass_extra_kwargs(self):
         column = sa.Column(sa.String(255))
-        field = column2field(column, instance=True, description="just a string")
+        field = column2field(
+            column, instance=True, metadata=dict(description="just a string")
+        )
         assert field.metadata["description"] == "just a string"
 
     def test_uuid_column2field(self):
@@ -314,11 +318,11 @@ class TestColumnToFieldClass:
 
 
 class TestFieldFor:
-    def test_field_for(self, models, session):
+    def test_field_for(self, models):
         field = field_for(models.Student, "full_name")
         assert type(field) is fields.Str
 
-        field = field_for(models.Student, "current_school", session=session)
+        field = field_for(models.Student, "current_school")
         assert type(field) is Related
 
         field = field_for(models.Student, "full_name", field_class=fields.Date)


### PR DESCRIPTION
Running the tests and failing on warnings (`pytest -W error`) succeeds