### PR TITLE
Don't accept arbitrary arguments to auto_field

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 Other changes:
 
 * Passing arbitrary keyword arguments to `auto_field <marshmallow_sqlalchemy.auto_field>`
-  is no longer supported. Use the ``metadata`` argument to pass metadata
+  is no longer supported (:pr:`647`). Use the ``metadata`` argument to pass metadata
   to the generated field instead.
 
 .. code-block:: python

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,25 @@
 Changelog
 ---------
 
+1.4.0 (unreleased)
+++++++++++++++++++
+
+Other changes:
+
+* Passing arbitrary keyword arguments to `auto_field <marshmallow_sqlalchemy.auto_field>`
+  is no longer supported. Use the ``metadata`` argument to pass metadata
+  to the generated field instead.
+
+.. code-block:: python
+
+    # Before
+    auto_field(description="The name of the artist")
+    # On marshmallow 3, this raises a warning: "RemovedInMarshmallow4Warning: Passing field metadata as keyword arguments is deprecated."
+    # On marshmallow 4, this raises an error: "TypeError: Field.__init__() got an unexpected keyword argument 'description'"
+
+    # After
+    auto_field(metadata=dict(description="The name of the artist"))
+
 1.3.0 (2025-01-11)
 ++++++++++++++++++
 

--- a/src/marshmallow_sqlalchemy/convert.py
+++ b/src/marshmallow_sqlalchemy/convert.py
@@ -62,33 +62,6 @@ def _enum_field_factory(
     return fields.Enum if data_type.enum_class else fields.Raw
 
 
-def _field_update_kwargs(
-    field_class: type[fields.Field] | functools.partial,
-    field_kwargs: dict[str, Any],
-    kwargs: dict[str, Any],
-) -> dict[str, Any]:
-    if not kwargs:
-        return field_kwargs
-
-    if isinstance(field_class, functools.partial):
-        # Unwrap partials, assuming that they bind a Field to arguments
-        field_class = cast(functools.partial, field_class.func)
-
-    possible_field_keywords = {
-        key
-        for cls in inspect.getmro(cast(type[fields.Field], field_class))
-        for key, param in inspect.signature(cls.__init__).parameters.items()  # type: ignore[misc]
-        if param.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
-        or param.kind is inspect.Parameter.KEYWORD_ONLY
-    }
-    for k, v in kwargs.items():
-        if k in possible_field_keywords:
-            field_kwargs[k] = v
-        else:
-            field_kwargs["metadata"][k] = v
-    return field_kwargs
-
-
 class ModelConverter:
     """Converts a SQLAlchemy model into a dictionary of corresponding
     marshmallow `Fields <marshmallow.fields.Field>`.
@@ -252,17 +225,14 @@ class ModelConverter:
         if not instance:
             return field_class
         field_kwargs = self._get_field_kwargs_for_property(prop)
-        _field_update_kwargs(field_class, field_kwargs, kwargs)
+        field_kwargs.update(kwargs)
         ret = field_class(**field_kwargs)
         if (
             hasattr(prop, "direction")
             and self.DIRECTION_MAPPING[prop.direction.name]
             and prop.uselist is True
         ):
-            related_list_kwargs = _field_update_kwargs(
-                RelatedList, self.get_base_kwargs(), kwargs
-            )
-            ret = RelatedList(ret, **related_list_kwargs)
+            ret = RelatedList(ret, **{**self.get_base_kwargs(), **kwargs})
         return ret
 
     @overload
@@ -290,8 +260,7 @@ class ModelConverter:
             return field_class
         field_kwargs = self.get_base_kwargs()
         self._add_column_kwargs(field_kwargs, column)
-        _field_update_kwargs(field_class, field_kwargs, kwargs)
-        return field_class(**field_kwargs)
+        return field_class(**{**field_kwargs, **kwargs})
 
     @overload
     def field_for(
@@ -352,10 +321,7 @@ class ModelConverter:
             **kwargs,
         )
         if remote_with_local_multiplicity:
-            related_list_kwargs = _field_update_kwargs(
-                RelatedList, self.get_base_kwargs(), kwargs
-            )
-            return RelatedList(converted_prop, **related_list_kwargs)
+            return RelatedList(converted_prop, **{**self.get_base_kwargs(), **kwargs})
         else:
             return converted_prop
 

--- a/tests/test_sqlalchemy_schema.py
+++ b/tests/test_sqlalchemy_schema.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from importlib.metadata import version
+
 import marshmallow
 import pytest
 import sqlalchemy as sa
@@ -672,3 +674,27 @@ def test_auto_schema_with_table_allows_subclasses_to_override_include_fk_with_ex
     assert "id" in schema2.fields
     assert "inherited_field" in schema2.fields
     assert "current_school_id" in schema2.fields
+
+
+def test_auto_field_does_not_accept_arbitrary_kwargs(models):
+    if int(version("marshmallow")[0]) < 4:
+        from marshmallow.warnings import RemovedInMarshmallow4Warning
+
+        with pytest.warns(
+            RemovedInMarshmallow4Warning,
+            match="Passing field metadata as keyword arguments is deprecated",
+        ):
+
+            class CourseSchema(SQLAlchemyAutoSchema):
+                class Meta:
+                    model = models.Course
+
+                name = auto_field(description="A course name")
+    else:
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+
+            class CourseSchema(SQLAlchemyAutoSchema):  # type: ignore[no-redef]
+                class Meta:
+                    model = models.Course
+
+                name = auto_field(description="A course name")


### PR DESCRIPTION
since https://github.com/marshmallow-code/marshmallow-sqlalchemy/pull/369, we allowed users to pass arbitrary arguments without getting a warning, implicitly passing non-field kwargs as `metadata` to the generated field.

better for users to get a warning or error, as non-field kwargs are likely to be user error.