### PR TITLE
Propose change for subclass inherited_fields override when include_fk=False

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+(unreleased)
+++++++++++++
+
+Bug fixes:
+
+* Fix inheritance of declared fields that match then name of a foreign key column
+  when the ``include_fk`` option is set to ``False`` (:pr:`657`).
+  Thanks :user:`carterjc` for the PR.
+
 1.4.0 (2025-01-19)
 ++++++++++++++++++
 

--- a/src/marshmallow_sqlalchemy/schema.py
+++ b/src/marshmallow_sqlalchemy/schema.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import inspect
 from typing import TYPE_CHECKING, Any, cast
 
 import sqlalchemy as sa
 from marshmallow.fields import Field
-from marshmallow.schema import Schema, SchemaMeta, SchemaOpts
+from marshmallow.schema import Schema, SchemaMeta, SchemaOpts, _get_fields
 
 from .convert import ModelConverter
 from .exceptions import IncorrectSchemaTypeError
@@ -118,7 +119,7 @@ class SQLAlchemySchemaMeta(SchemaMeta):
             cls_fields,
             # Filter out fields generated from foreign key columns
             # if include_fk is set to False in the options
-            mcs._maybe_filter_foreign_keys(inherited_fields, opts=opts),
+            mcs._maybe_filter_foreign_keys(inherited_fields, opts=opts, klass=klass),
             dict_cls,
         )
         fields.update(mcs.get_declared_sqla_fields(fields, converter, opts, dict_cls))
@@ -159,6 +160,7 @@ class SQLAlchemySchemaMeta(SchemaMeta):
         fields: list[tuple[str, Field]],
         *,
         opts: SQLAlchemySchemaOpts,
+        klass: SchemaMeta,
     ) -> list[tuple[str, Field]]:
         if opts.model is not None or opts.table is not None:
             if not hasattr(opts, "include_fk") or opts.include_fk is True:
@@ -168,7 +170,31 @@ class SQLAlchemySchemaMeta(SchemaMeta):
                 for column in sa.inspect(opts.model or opts.table).columns  # type: ignore[union-attr]
                 if column.foreign_keys
             }
-            return [(name, field) for name, field in fields if name not in foreign_keys]
+
+            schema_overrides = [
+                base
+                for base in inspect.getmro(klass)
+                if issubclass(base, Schema)
+                and not issubclass(base, SQLAlchemyAutoSchema)
+            ]
+
+            def is_overridden(field: str) -> bool:
+                return any(
+                    field
+                    in [
+                        name
+                        for name, _ in _get_fields(
+                            getattr(base, "_declared_fields", base.__dict__)
+                        )
+                    ]
+                    for base in schema_overrides
+                )
+
+            return [
+                (name, field)
+                for name, field in fields
+                if name not in foreign_keys or is_overridden(name)
+            ]
         return fields
 
 

--- a/src/marshmallow_sqlalchemy/schema.py
+++ b/src/marshmallow_sqlalchemy/schema.py
@@ -171,14 +171,14 @@ class SQLAlchemySchemaMeta(SchemaMeta):
                 if column.foreign_keys
             }
 
-            schema_overrides = [
+            non_auto_schema_bases = [
                 base
                 for base in inspect.getmro(klass)
                 if issubclass(base, Schema)
                 and not issubclass(base, SQLAlchemyAutoSchema)
             ]
 
-            def is_overridden(field: str) -> bool:
+            def is_declared_field(field: str) -> bool:
                 return any(
                     field
                     in [
@@ -187,20 +187,22 @@ class SQLAlchemySchemaMeta(SchemaMeta):
                             getattr(base, "_declared_fields", base.__dict__)
                         )
                     ]
-                    for base in schema_overrides
+                    for base in non_auto_schema_bases
                 )
 
             return [
                 (name, field)
                 for name, field in fields
-                if name not in foreign_keys or is_overridden(name)
+                if name not in foreign_keys or is_declared_field(name)
             ]
         return fields
 
 
 class SQLAlchemyAutoSchemaMeta(SQLAlchemySchemaMeta):
     @classmethod
-    def get_declared_sqla_fields(cls, base_fields, converter, opts, dict_cls):
+    def get_declared_sqla_fields(
+        cls, base_fields, converter: ModelConverter, opts, dict_cls
+    ):
         fields = dict_cls()
         if opts.table is not None:
             fields.update(

--- a/tests/test_sqlalchemy_schema.py
+++ b/tests/test_sqlalchemy_schema.py
@@ -681,29 +681,31 @@ def test_auto_schema_with_table_allows_subclasses_to_override_include_fk_with_ex
     assert "current_school_id" in schema2.fields
 
 
-def test_auto_schema_with_model_allows_schema_extensions_to_override_include_fk_with_explicit_inherited_field(
+def test_auto_schema_with_model_can_inherit_declared_field_for_foreign_key_column_when_include_fk_is_false(
     models,
 ):
-    class OverrideSchema(Schema):
+    class BaseTeacherSchema(Schema):
         current_school_id = fields.Integer()
 
-    class TeacherSchema(SQLAlchemyAutoSchema, OverrideSchema):
+    class TeacherSchema(BaseTeacherSchema, SQLAlchemyAutoSchema):
         class Meta:
             model = models.Teacher
+            include_fk = False
 
     schema = TeacherSchema()
     assert "current_school_id" in schema.fields
 
 
-def test_auto_schema_with_table_allows_schema_extensions_to_override_include_fk_with_explicit_inherited_field(
+def test_auto_schema_with_table_can_inherit_declared_field_for_foreign_key_column_when_include_fk_is_false(
     models,
 ):
-    class OverrideSchema(Schema):
+    class BaseTeacherSchema(Schema):
         current_school_id = fields.Integer()
 
-    class TeacherSchema(SQLAlchemyAutoSchema, OverrideSchema):
+    class TeacherSchema(BaseTeacherSchema, SQLAlchemyAutoSchema):
         class Meta:
             table = models.Teacher.__table__
+            include_fk = False
 
     schema = TeacherSchema()
     assert "current_school_id" in schema.fields

--- a/tests/test_sqlalchemy_schema.py
+++ b/tests/test_sqlalchemy_schema.py
@@ -681,6 +681,34 @@ def test_auto_schema_with_table_allows_subclasses_to_override_include_fk_with_ex
     assert "current_school_id" in schema2.fields
 
 
+def test_auto_schema_with_model_allows_schema_extensions_to_override_include_fk_with_explicit_inherited_field(
+    models,
+):
+    class OverrideSchema(Schema):
+        current_school_id = fields.Integer()
+
+    class TeacherSchema(SQLAlchemyAutoSchema, OverrideSchema):
+        class Meta:
+            model = models.Teacher
+
+    schema = TeacherSchema()
+    assert "current_school_id" in schema.fields
+
+
+def test_auto_schema_with_table_allows_schema_extensions_to_override_include_fk_with_explicit_inherited_field(
+    models,
+):
+    class OverrideSchema(Schema):
+        current_school_id = fields.Integer()
+
+    class TeacherSchema(SQLAlchemyAutoSchema, OverrideSchema):
+        class Meta:
+            table = models.Teacher.__table__
+
+    schema = TeacherSchema()
+    assert "current_school_id" in schema.fields
+
+
 def test_auto_field_does_not_accept_arbitrary_kwargs(models):
     if int(version("marshmallow")[0]) < 4:
         from marshmallow.warnings import RemovedInMarshmallow4Warning
@@ -695,6 +723,7 @@ def test_auto_field_does_not_accept_arbitrary_kwargs(models):
                     model = models.Course
 
                 name = auto_field(description="A course name")
+
     else:
         with pytest.raises(TypeError, match="unexpected keyword argument"):
 


### PR DESCRIPTION
Hi again, hope all is well.

This is sorta an addendum to https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/440.

I was running into an issue when upgrading my marshmallow-sqlalchemy version to 1.3 on a project because of the PR on the above report.

The existing tests seem to work because `get_declared_fields` in `marshmallow/schema.py` concatenates inherited_fields with class_fields. However, when trying to extend an AutoSchema with a marshmallow.schema.Schema to override a FK field, the new `_maybe_filter_foreign_keys` filters these fields out as well. I provided a test case in the PR to explain what I mean.

The way I thought to overcome this problem is by differentiating between the types of inheritance by some discriminator. I tried when fields are inherited from a Schema that is not a SQLAlchemySchema, the motivation being that SQLAlchemyAutoSchema introduces the include_fk field and the inheritance/overriding of this field is the nexus of the entire issue. I'm not sure if this is the best solution, but does work for the case that brought this issue to my attention and the existing test suite.

I'm open to any thoughts or suggestions. Thanks for all of your work!