### PR TITLE
Fix type compatibility with marshmallow v3 and v4

### DIFF
--- a/src/marshmallow_sqlalchemy/fields.py
+++ b/src/marshmallow_sqlalchemy/fields.py
@@ -160,4 +160,4 @@ def get_primary_keys(model: type[DeclarativeMeta]) -> list[MapperProperty]:
 
 
 def ensure_list(value: Any) -> list:
-    return value if is_iterable_but_not_string(value) else [value]
+    return list(value) if is_iterable_but_not_string(value) else [value]

--- a/src/marshmallow_sqlalchemy/load_instance_mixin.py
+++ b/src/marshmallow_sqlalchemy/load_instance_mixin.py
@@ -8,7 +8,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
+import importlib.metadata
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any, Generic, TypeVar, Union, cast
 
 import marshmallow as ma
 from sqlalchemy.ext.declarative import DeclarativeMeta
@@ -17,10 +19,16 @@ from sqlalchemy.orm.exc import ObjectDeletedError
 
 from .fields import get_primary_keys
 
-if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
-
+_LoadDataV3 = Union[Mapping[str, Any], Iterable[Mapping[str, Any]]]
+_LoadDataV4 = Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]
+_LoadDataT = TypeVar("_LoadDataT", _LoadDataV3, _LoadDataV4)
 _ModelType = TypeVar("_ModelType", bound=DeclarativeMeta)
+
+
+def _cast_data(data):
+    if int(importlib.metadata.version("marshmallow")[0]) >= 4:
+        return cast(_LoadDataV4, data)
+    return cast(_LoadDataV3, data)
 
 
 class LoadInstanceMixin:
@@ -114,7 +122,7 @@ class LoadInstanceMixin:
 
         def load(
             self,
-            data: Mapping[str, Any] | Iterable[Mapping[str, Any]],
+            data: _LoadDataT,
             *,
             session: Session | None = None,
             instance: _ModelType | None = None,
@@ -136,13 +144,13 @@ class LoadInstanceMixin:
                 raise ValueError("Deserialization requires a session")
             self.instance = instance or self.instance
             try:
-                return cast(ma.Schema, super()).load(data, **kwargs)
+                return cast(ma.Schema, super()).load(_cast_data(data), **kwargs)
             finally:
                 self.instance = None
 
         def validate(
             self,
-            data: Mapping[str, Any] | Iterable[Mapping[str, Any]],
+            data: _LoadDataT,
             *,
             session: Session | None = None,
             **kwargs,
@@ -151,7 +159,7 @@ class LoadInstanceMixin:
             self._session = session or self._session
             if not (self.transient or self.session):
                 raise ValueError("Validation requires a session")
-            return cast(ma.Schema, super()).validate(data, **kwargs)
+            return cast(ma.Schema, super()).validate(_cast_data(data), **kwargs)
 
         def _split_model_kwargs_association(self, data):
             """Split serialized attrs to ensure association proxies are passed separately.


### PR DESCRIPTION
see https://github.com/marshmallow-code/marshmallow/pull/2795 , the type annotation for `data` was changed in v4