### PR TITLE
fix: improve perf of _maybe_filter_foreign_keys method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+(unreleased)
+++++++++++++
+
+Bug fixes:
+
+* Fix memory usage regression in 1.4.1 (:issue:`665`).
+  Thanks :user:`mistercrunch` for reporting and sending a PR.
+
 1.4.1 (2025-02-10)
 ++++++++++++++++++
 

--- a/src/marshmallow_sqlalchemy/schema.py
+++ b/src/marshmallow_sqlalchemy/schema.py
@@ -178,22 +178,16 @@ class SQLAlchemySchemaMeta(SchemaMeta):
                 and not issubclass(base, SQLAlchemyAutoSchema)
             ]
 
-            def is_declared_field(field: str) -> bool:
-                return any(
-                    field
-                    in [
-                        name
-                        for name, _ in _get_fields(
-                            getattr(base, "_declared_fields", base.__dict__)
-                        )
-                    ]
-                    for base in non_auto_schema_bases
-                )
+            # Pre-compute declared fields only once
+            declared_fields = set()
+            for base in non_auto_schema_bases:
+                base_fields = getattr(base, "_declared_fields", base.__dict__)
+                declared_fields.update(name for name, _ in _get_fields(base_fields))
 
             return [
                 (name, field)
                 for name, field in fields
-                if name not in foreign_keys or is_declared_field(name)
+                if name not in foreign_keys or name in declared_fields
             ]
         return fields
 

--- a/src/marshmallow_sqlalchemy/schema.py
+++ b/src/marshmallow_sqlalchemy/schema.py
@@ -179,7 +179,7 @@ class SQLAlchemySchemaMeta(SchemaMeta):
             ]
 
             # Pre-compute declared fields only once
-            declared_fields = set()
+            declared_fields: set[Any] = set()
             for base in non_auto_schema_bases:
                 base_fields = getattr(base, "_declared_fields", base.__dict__)
                 declared_fields.update(name for name, _ in _get_fields(base_fields))


### PR DESCRIPTION
Optimizing a method to try and address the issue described here -> https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/665

A bit of a shot in the dark, but this optimization should help significantly. Unclear if it will address the memory-related issue, would have to dig deeper in the call stack to understand what it does.

I have to admit I don't actually understand what the code does, so this optimization is purely theoretical.